### PR TITLE
bugfix: Resolve ttl issues

### DIFF
--- a/obsrvr-lake/stellar-query-api/go/handlers_silver.go
+++ b/obsrvr-lake/stellar-query-api/go/handlers_silver.go
@@ -29,6 +29,20 @@ func NewSilverHandlers(legacyReader *UnifiedSilverReader, unifiedReader *Unified
 	}
 }
 
+func normalizeTTLEntryForCurrentLedger(entry *TTLEntry, currentLedger int64) {
+	if entry == nil {
+		return
+	}
+	entry.LedgersRemaining = entry.LiveUntilLedger - currentLedger
+	entry.Expired = entry.LedgersRemaining <= 0
+}
+
+func normalizeTTLEntriesForCurrentLedger(entries []TTLEntry, currentLedger int64) {
+	for i := range entries {
+		normalizeTTLEntryForCurrentLedger(&entries[i], currentLedger)
+	}
+}
+
 // logMismatch logs when legacy and unified reader results differ (for hybrid mode validation)
 func logMismatch(endpoint string, legacyCount, unifiedCount int, details string) {
 	log.Printf("⚠️ HYBRID MISMATCH [%s]: legacy=%d, unified=%d | %s", endpoint, legacyCount, unifiedCount, details)
@@ -2937,37 +2951,139 @@ func (h *SilverHandlers) HandleContractCode(w http.ResponseWriter, r *http.Reque
 	})
 }
 
-// HandleTTL returns TTL entry for a specific key hash
+// HandleTTL returns TTL entries.
+//
+// Lookup modes:
+//   - key_hash=<hex>            → single TTL entry by hash
+//   - contract_id=C...          → all TTL entries for the contract's storage (paginated)
+//
 // GET /api/v1/silver/soroban/ttl?key_hash=...
+// GET /api/v1/silver/soroban/ttl?contract_id=C...&limit=100&cursor=...
 func (h *SilverHandlers) HandleTTL(w http.ResponseWriter, r *http.Request) {
-	keyHash := r.URL.Query().Get("key_hash")
-	if keyHash == "" {
-		respondError(w, "key_hash parameter required", http.StatusBadRequest)
-		return
-	}
-
-	var ttl *TTLEntry
-	var err error
-
-	if h.unifiedReader != nil {
-		ttl, err = h.unifiedReader.GetTTL(r.Context(), keyHash)
-	} else {
+	if h.unifiedReader == nil {
 		respondError(w, "ttl endpoint requires unified reader", http.StatusInternalServerError)
 		return
 	}
 
+	keyHash := r.URL.Query().Get("key_hash")
+	contractID := r.URL.Query().Get("contract_id")
+
+	if keyHash == "" && contractID == "" {
+		respondError(w, "key_hash or contract_id parameter required", http.StatusBadRequest)
+		return
+	}
+	if keyHash != "" && contractID != "" {
+		respondError(w, "specify key_hash or contract_id, not both", http.StatusBadRequest)
+		return
+	}
+
+	currentLedger, err := h.unifiedReader.GetCurrentLedger(r.Context())
+	if err != nil {
+		respondError(w, "failed to get current ledger: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if keyHash != "" {
+		ttl, err := h.unifiedReader.GetTTL(r.Context(), keyHash)
+		if err != nil {
+			respondError(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if ttl == nil {
+			respondError(w, "TTL entry not found", http.StatusNotFound)
+			return
+		}
+		normalizeTTLEntryForCurrentLedger(ttl, currentLedger)
+		respondJSON(w, map[string]interface{}{"ttl": ttl})
+		return
+	}
+
+	cursor, err := DecodeTTLCursor(r.URL.Query().Get("cursor"))
+	if err != nil {
+		respondError(w, "invalid cursor: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	filters := TTLFilters{
+		ContractID: contractID,
+		Limit:      parseLimit(r, 100, 1000),
+		Cursor:     cursor,
+	}
+
+	entries, nextCursor, hasMore, err := h.unifiedReader.GetTTLByContract(r.Context(), contractID, filters)
 	if err != nil {
 		respondError(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	normalizeTTLEntriesForCurrentLedger(entries, currentLedger)
 
+	resp := map[string]interface{}{
+		"contract_id": contractID,
+		"ttl_entries": entries,
+		"count":       len(entries),
+		"has_more":    hasMore,
+	}
+	if nextCursor != "" {
+		resp["cursor"] = nextCursor
+	}
+	respondJSON(w, resp)
+}
+
+// HandleTTLResolve computes the ledger-key hash for a (contract_id, durability, ScVal key)
+// tuple server-side and returns the matching TTL entry. Removes the need for clients to
+// XDR-marshal the LedgerKey themselves.
+//
+// GET /api/v1/silver/soroban/ttl/resolve?contract_id=C...&durability=persistent&key=<base64-ScVal>
+// GET /api/v1/silver/soroban/ttl/resolve?contract_id=C...&durability=persistent&key_type=instance
+func (h *SilverHandlers) HandleTTLResolve(w http.ResponseWriter, r *http.Request) {
+	if h.unifiedReader == nil {
+		respondError(w, "ttl endpoint requires unified reader", http.StatusInternalServerError)
+		return
+	}
+
+	contractID := r.URL.Query().Get("contract_id")
+	durabilityParam := strings.ToLower(r.URL.Query().Get("durability"))
+	keyB64 := r.URL.Query().Get("key")
+	keyType := strings.ToLower(r.URL.Query().Get("key_type"))
+
+	if contractID == "" {
+		respondError(w, "contract_id required", http.StatusBadRequest)
+		return
+	}
+	if keyB64 == "" && keyType == "" {
+		respondError(w, "key (base64 ScVal) or key_type=instance required", http.StatusBadRequest)
+		return
+	}
+	if keyB64 != "" && keyType != "" {
+		respondError(w, "specify key or key_type, not both", http.StatusBadRequest)
+		return
+	}
+
+	keyHash, err := computeContractDataKeyHash(contractID, durabilityParam, keyB64, keyType)
+	if err != nil {
+		respondError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	ttl, err := h.unifiedReader.GetTTL(r.Context(), keyHash)
+	if err != nil {
+		respondError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	if ttl == nil {
 		respondError(w, "TTL entry not found", http.StatusNotFound)
 		return
 	}
 
+	currentLedger, err := h.unifiedReader.GetCurrentLedger(r.Context())
+	if err != nil {
+		respondError(w, "failed to get current ledger: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	normalizeTTLEntryForCurrentLedger(ttl, currentLedger)
+
 	respondJSON(w, map[string]interface{}{
-		"ttl": ttl,
+		"key_hash": keyHash,
+		"ttl":      ttl,
 	})
 }
 

--- a/obsrvr-lake/stellar-query-api/go/routes_silver.go
+++ b/obsrvr-lake/stellar-query-api/go/routes_silver.go
@@ -68,6 +68,7 @@ func (app *application) registerSilverRoutes(router *mux.Router) {
 	router.HandleFunc("/api/v1/silver/tx/{hash}/effects", silverHandlers.HandleEffectsByTransactionAlias).Methods("GET")
 	router.HandleFunc("/api/v1/silver/soroban/contract-code", silverHandlers.HandleContractCode).Methods("GET")
 	router.HandleFunc("/api/v1/silver/soroban/ttl", silverHandlers.HandleTTL).Methods("GET")
+	router.HandleFunc("/api/v1/silver/soroban/ttl/resolve", silverHandlers.HandleTTLResolve).Methods("GET")
 	router.HandleFunc("/api/v1/silver/soroban/ttl/expiring", silverHandlers.HandleTTLExpiring).Methods("GET")
 	router.HandleFunc("/api/v1/silver/soroban/ttl/expired", silverHandlers.HandleTTLExpired).Methods("GET")
 	router.HandleFunc("/api/v1/silver/soroban/evicted-keys", silverHandlers.HandleEvictedKeys).Methods("GET")

--- a/obsrvr-lake/stellar-query-api/go/silver_reader.go
+++ b/obsrvr-lake/stellar-query-api/go/silver_reader.go
@@ -1409,11 +1409,15 @@ type TTLEntry struct {
 	Expired            bool      `json:"expired"`
 	LastModifiedLedger int64     `json:"last_modified_ledger"`
 	ClosedAt           time.Time `json:"closed_at"`
+	// Populated when the TTL row is joined against contract_data_current.
+	ContractID string `json:"contract_id,omitempty"`
+	Durability string `json:"durability,omitempty"`
 }
 
 // TTLFilters contains filter options for TTL queries
 type TTLFilters struct {
 	KeyHash       string
+	ContractID    string
 	WithinLedgers int64 // Entries expiring within N ledgers
 	ExpiredOnly   bool  // Only show expired entries
 	Limit         int

--- a/obsrvr-lake/stellar-query-api/go/ttl_normalize_test.go
+++ b/obsrvr-lake/stellar-query-api/go/ttl_normalize_test.go
@@ -1,0 +1,33 @@
+package main
+
+import "testing"
+
+func TestNormalizeTTLEntryForCurrentLedger(t *testing.T) {
+	t.Run("expired when live_until is in the past even if stored flag was false", func(t *testing.T) {
+		entry := &TTLEntry{
+			LiveUntilLedger: 100,
+			Expired:         false,
+		}
+		normalizeTTLEntryForCurrentLedger(entry, 150)
+		if entry.LedgersRemaining != -50 {
+			t.Fatalf("expected ledgers_remaining=-50, got %d", entry.LedgersRemaining)
+		}
+		if !entry.Expired {
+			t.Fatalf("expected expired=true")
+		}
+	})
+
+	t.Run("not expired when live_until is still ahead", func(t *testing.T) {
+		entry := &TTLEntry{
+			LiveUntilLedger: 250,
+			Expired:         true,
+		}
+		normalizeTTLEntryForCurrentLedger(entry, 150)
+		if entry.LedgersRemaining != 100 {
+			t.Fatalf("expected ledgers_remaining=100, got %d", entry.LedgersRemaining)
+		}
+		if entry.Expired {
+			t.Fatalf("expected expired=false")
+		}
+	})
+}

--- a/obsrvr-lake/stellar-query-api/go/ttl_resolve.go
+++ b/obsrvr-lake/stellar-query-api/go/ttl_resolve.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"strings"
 
 	"github.com/stellar/go/strkey"
 	"github.com/stellar/go/xdr"
@@ -37,8 +38,10 @@ func computeContractDataKeyHash(contractID, durability, keyB64, keyType string) 
 	switch {
 	case keyType == "instance":
 		keyScVal = xdr.ScVal{Type: xdr.ScValTypeScvLedgerKeyContractInstance}
+	case keyType != "":
+		return "", fmt.Errorf("unsupported key_type %q; only 'instance' is supported", keyType)
 	case keyB64 != "":
-		decoded, err := base64.StdEncoding.DecodeString(keyB64)
+		decoded, err := decodeScValBase64(keyB64)
 		if err != nil {
 			return "", fmt.Errorf("decode key (base64): %w", err)
 		}
@@ -78,4 +81,29 @@ func parseDurability(s string) (xdr.ContractDataDurability, error) {
 	default:
 		return 0, fmt.Errorf("durability must be 'persistent' or 'temporary', got %q", s)
 	}
+}
+
+func decodeScValBase64(s string) ([]byte, error) {
+	candidates := []string{
+		s,
+		strings.ReplaceAll(s, " ", "+"),
+	}
+	encodings := []*base64.Encoding{
+		base64.StdEncoding,
+		base64.RawStdEncoding,
+		base64.URLEncoding,
+		base64.RawURLEncoding,
+	}
+
+	var lastErr error
+	for _, candidate := range candidates {
+		for _, enc := range encodings {
+			decoded, err := enc.DecodeString(candidate)
+			if err == nil {
+				return decoded, nil
+			}
+			lastErr = err
+		}
+	}
+	return nil, lastErr
 }

--- a/obsrvr-lake/stellar-query-api/go/ttl_resolve.go
+++ b/obsrvr-lake/stellar-query-api/go/ttl_resolve.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/stellar/go/strkey"
+	"github.com/stellar/go/xdr"
+)
+
+// computeContractDataKeyHash builds the LedgerKey for a Soroban contract-data entry
+// and returns its hex-encoded SHA-256 hash (same scheme the ingester uses when
+// writing ttl_current.key_hash).
+//
+// Exactly one of keyB64 (base64 XDR-marshaled ScVal) or keyType ("instance") must
+// be provided. durability must be "persistent" or "temporary"; defaults to
+// "persistent" when empty.
+func computeContractDataKeyHash(contractID, durability, keyB64, keyType string) (string, error) {
+	rawContract, err := strkey.Decode(strkey.VersionByteContract, contractID)
+	if err != nil {
+		return "", fmt.Errorf("decode contract_id: %w", err)
+	}
+	if len(rawContract) != 32 {
+		return "", fmt.Errorf("unexpected contract_id length: %d", len(rawContract))
+	}
+	var contractHash xdr.ContractId
+	copy(contractHash[:], rawContract)
+
+	dur, err := parseDurability(durability)
+	if err != nil {
+		return "", err
+	}
+
+	var keyScVal xdr.ScVal
+	switch {
+	case keyType == "instance":
+		keyScVal = xdr.ScVal{Type: xdr.ScValTypeScvLedgerKeyContractInstance}
+	case keyB64 != "":
+		decoded, err := base64.StdEncoding.DecodeString(keyB64)
+		if err != nil {
+			return "", fmt.Errorf("decode key (base64): %w", err)
+		}
+		if err := xdr.SafeUnmarshal(decoded, &keyScVal); err != nil {
+			return "", fmt.Errorf("unmarshal key ScVal: %w", err)
+		}
+	default:
+		return "", fmt.Errorf("key or key_type required")
+	}
+
+	ledgerKey := xdr.LedgerKey{
+		Type: xdr.LedgerEntryTypeContractData,
+		ContractData: &xdr.LedgerKeyContractData{
+			Contract: xdr.ScAddress{
+				Type:       xdr.ScAddressTypeScAddressTypeContract,
+				ContractId: &contractHash,
+			},
+			Key:        keyScVal,
+			Durability: dur,
+		},
+	}
+
+	raw, err := ledgerKey.MarshalBinary()
+	if err != nil {
+		return "", fmt.Errorf("marshal ledger key: %w", err)
+	}
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func parseDurability(s string) (xdr.ContractDataDurability, error) {
+	switch s {
+	case "", "persistent":
+		return xdr.ContractDataDurabilityPersistent, nil
+	case "temporary":
+		return xdr.ContractDataDurabilityTemporary, nil
+	default:
+		return 0, fmt.Errorf("durability must be 'persistent' or 'temporary', got %q", s)
+	}
+}

--- a/obsrvr-lake/stellar-query-api/go/ttl_resolve_test.go
+++ b/obsrvr-lake/stellar-query-api/go/ttl_resolve_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	"github.com/stellar/go/xdr"
+)
+
+func TestDecodeScValBase64SupportsCommonQueryEncodings(t *testing.T) {
+	sym := xdr.ScSymbol("Balance")
+	val := xdr.ScVal{Type: xdr.ScValTypeScvSymbol, Sym: &sym}
+	raw, err := val.MarshalBinary()
+	if err != nil {
+		t.Fatalf("marshal scval: %v", err)
+	}
+
+	std := base64.StdEncoding.EncodeToString(raw)
+	url := base64.URLEncoding.EncodeToString(raw)
+
+	for name, input := range map[string]string{
+		"std":          std,
+		"std_plus_space": strings.ReplaceAll(std, "+", " "),
+		"url":          url,
+	} {
+		t.Run(name, func(t *testing.T) {
+			decoded, err := decodeScValBase64(input)
+			if err != nil {
+				t.Fatalf("decodeScValBase64(%q): %v", input, err)
+			}
+			if string(decoded) != string(raw) {
+				t.Fatalf("decoded bytes mismatch")
+			}
+		})
+	}
+}
+
+func TestComputeContractDataKeyHashRejectsUnsupportedKeyType(t *testing.T) {
+	_, err := computeContractDataKeyHash(
+		"CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+		"persistent",
+		"",
+		"balance",
+	)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "unsupported key_type") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/obsrvr-lake/stellar-query-api/go/unified_duckdb_reader.go
+++ b/obsrvr-lake/stellar-query-api/go/unified_duckdb_reader.go
@@ -3019,7 +3019,8 @@ func (r *UnifiedDuckDBReader) GetTTL(ctx context.Context, keyHash string) (*TTLE
 }
 
 // GetTTLByContract returns TTL entries for all storage keys belonging to a contract.
-// Joins ttl_current against contract_data_current on key_hash in both hot and cold schemas.
+// It deduplicates contract-data and TTL rows across hot/cold so keys are not dropped
+// when the two tables transition between storage tiers at different times.
 func (r *UnifiedDuckDBReader) GetTTLByContract(ctx context.Context, contractID string, filters TTLFilters) ([]TTLEntry, string, bool, error) {
 	var cursorClause string
 	args := []interface{}{contractID}
@@ -3036,39 +3037,56 @@ func (r *UnifiedDuckDBReader) GetTTLByContract(ctx context.Context, contractID s
 		limit = 100
 	}
 
-	joinedSelect := func(ttlSchema, dataSchema string) string {
+	buildQuery := func(includeCold bool) string {
+		contractDataUnion := fmt.Sprintf(`
+			SELECT DISTINCT contract_id, key_hash, durability
+			FROM %s.contract_data_current
+			WHERE contract_id = $1
+		`, r.hotSchema)
+		ttlUnion := fmt.Sprintf(`
+			SELECT DISTINCT key_hash, live_until_ledger_seq, expired, last_modified_ledger, closed_at
+			FROM %s.ttl_current
+		`, r.hotSchema)
+
+		if includeCold {
+			contractDataUnion = fmt.Sprintf(`
+				%s
+				UNION
+				SELECT DISTINCT contract_id, key_hash, durability
+				FROM %s.contract_data_current
+				WHERE contract_id = $1
+			`, contractDataUnion, r.coldSchema)
+			ttlUnion = fmt.Sprintf(`
+				%s
+				UNION
+				SELECT DISTINCT key_hash, live_until_ledger_seq, expired, last_modified_ledger, closed_at
+				FROM %s.ttl_current
+			`, ttlUnion, r.coldSchema)
+		}
+
 		return fmt.Sprintf(`
+			WITH contract_keys AS (
+				%s
+			), ttl_rows AS (
+				%s
+			)
 			SELECT t.key_hash, t.live_until_ledger_seq, t.expired, t.last_modified_ledger, t.closed_at,
-				cd.contract_id, cd.durability
-			FROM %s.ttl_current t
-			JOIN %s.contract_data_current cd ON cd.key_hash = t.key_hash
-			WHERE cd.contract_id = $1%s
-		`, ttlSchema, dataSchema, cursorClause)
+				ck.contract_id, ck.durability
+			FROM ttl_rows t
+			JOIN contract_keys ck ON ck.key_hash = t.key_hash
+			WHERE 1=1%s
+			ORDER BY t.live_until_ledger_seq ASC, t.key_hash ASC
+			LIMIT $%d
+		`, contractDataUnion, ttlUnion, cursorClause, argNum)
 	}
 
-	query := fmt.Sprintf(`
-		SELECT key_hash, live_until_ledger_seq, expired, last_modified_ledger, closed_at,
-			contract_id, durability
-		FROM (
-			%s
-			UNION ALL
-			%s
-		) combined
-		ORDER BY live_until_ledger_seq ASC, key_hash ASC
-		LIMIT $%d
-	`, joinedSelect(r.hotSchema, r.hotSchema), joinedSelect(r.coldSchema, r.coldSchema), argNum)
 	args = append(args, limit+1)
-
-	rows, err := r.db.QueryContext(ctx, query, args...)
+	rows, err := r.db.QueryContext(ctx, buildQuery(true), args...)
 	if err != nil {
-		// If cold tables missing, fall back to hot-only.
-		if strings.Contains(err.Error(), "does not exist") {
-			hotQuery := fmt.Sprintf(`
-				%s
-				ORDER BY live_until_ledger_seq ASC, key_hash ASC
-				LIMIT $%d
-			`, joinedSelect(r.hotSchema, r.hotSchema), argNum)
-			rows, err = r.db.QueryContext(ctx, hotQuery, args...)
+		errStr := err.Error()
+		if strings.Contains(errStr, "does not exist") &&
+			(strings.Contains(errStr, "ttl_current") || strings.Contains(errStr, "contract_data_current")) {
+			rows, err = r.db.QueryContext(ctx, buildQuery(false), args...)
 			if err != nil {
 				return nil, "", false, fmt.Errorf("unified GetTTLByContract (hot-only): %w", err)
 			}

--- a/obsrvr-lake/stellar-query-api/go/unified_duckdb_reader.go
+++ b/obsrvr-lake/stellar-query-api/go/unified_duckdb_reader.go
@@ -3018,6 +3018,93 @@ func (r *UnifiedDuckDBReader) GetTTL(ctx context.Context, keyHash string) (*TTLE
 	return &entry, nil
 }
 
+// GetTTLByContract returns TTL entries for all storage keys belonging to a contract.
+// Joins ttl_current against contract_data_current on key_hash in both hot and cold schemas.
+func (r *UnifiedDuckDBReader) GetTTLByContract(ctx context.Context, contractID string, filters TTLFilters) ([]TTLEntry, string, bool, error) {
+	var cursorClause string
+	args := []interface{}{contractID}
+	argNum := 2
+
+	if filters.Cursor != nil {
+		cursorClause = fmt.Sprintf(" AND (t.live_until_ledger_seq, t.key_hash) > ($%d, $%d)", argNum, argNum+1)
+		args = append(args, filters.Cursor.LiveUntilLedger, filters.Cursor.KeyHash)
+		argNum += 2
+	}
+
+	limit := filters.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+
+	joinedSelect := func(ttlSchema, dataSchema string) string {
+		return fmt.Sprintf(`
+			SELECT t.key_hash, t.live_until_ledger_seq, t.expired, t.last_modified_ledger, t.closed_at,
+				cd.contract_id, cd.durability
+			FROM %s.ttl_current t
+			JOIN %s.contract_data_current cd ON cd.key_hash = t.key_hash
+			WHERE cd.contract_id = $1%s
+		`, ttlSchema, dataSchema, cursorClause)
+	}
+
+	query := fmt.Sprintf(`
+		SELECT key_hash, live_until_ledger_seq, expired, last_modified_ledger, closed_at,
+			contract_id, durability
+		FROM (
+			%s
+			UNION ALL
+			%s
+		) combined
+		ORDER BY live_until_ledger_seq ASC, key_hash ASC
+		LIMIT $%d
+	`, joinedSelect(r.hotSchema, r.hotSchema), joinedSelect(r.coldSchema, r.coldSchema), argNum)
+	args = append(args, limit+1)
+
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		// If cold tables missing, fall back to hot-only.
+		if strings.Contains(err.Error(), "does not exist") {
+			hotQuery := fmt.Sprintf(`
+				%s
+				ORDER BY live_until_ledger_seq ASC, key_hash ASC
+				LIMIT $%d
+			`, joinedSelect(r.hotSchema, r.hotSchema), argNum)
+			rows, err = r.db.QueryContext(ctx, hotQuery, args...)
+			if err != nil {
+				return nil, "", false, fmt.Errorf("unified GetTTLByContract (hot-only): %w", err)
+			}
+		} else {
+			return nil, "", false, fmt.Errorf("unified GetTTLByContract: %w", err)
+		}
+	}
+	defer rows.Close()
+
+	var entries []TTLEntry
+	for rows.Next() {
+		var e TTLEntry
+		if err := rows.Scan(&e.KeyHash, &e.LiveUntilLedger, &e.Expired,
+			&e.LastModifiedLedger, &e.ClosedAt, &e.ContractID, &e.Durability); err != nil {
+			return nil, "", false, err
+		}
+		entries = append(entries, e)
+	}
+
+	hasMore := len(entries) > limit
+	if hasMore {
+		entries = entries[:limit]
+	}
+
+	var nextCursor string
+	if hasMore && len(entries) > 0 {
+		last := entries[len(entries)-1]
+		nextCursor = TTLCursor{
+			LiveUntilLedger: last.LiveUntilLedger,
+			KeyHash:         last.KeyHash,
+		}.Encode()
+	}
+
+	return entries, nextCursor, hasMore, nil
+}
+
 // GetTTLExpiring returns TTL entries expiring within N ledgers from unified storage
 func (r *UnifiedDuckDBReader) GetTTLExpiring(ctx context.Context, currentLedger int64, filters TTLFilters) ([]TTLEntry, string, bool, error) {
 	var conditions []string


### PR DESCRIPTION
This pull request significantly enhances the Soroban TTL (Time-To-Live) API endpoints in the Silver Query API by introducing new features for querying and resolving TTL entries, improving normalization logic, and expanding test coverage. The changes make it easier to look up TTLs by contract, resolve TTLs by contract/key, and ensure TTL data is always accurate relative to the current ledger.

**New TTL Query and Resolution Features:**

* Added support for querying all TTL entries for a given contract (`contract_id`) with pagination, in addition to the existing single-key lookup (`key_hash`). The endpoint `/api/v1/silver/soroban/ttl` now supports both modes, and returns normalized TTL data. [[1]](diffhunk://#diff-563b7ef3ceae35a7a1b6899481fc8e5c36403d4cea6bacb1626775a5c7ed782fL2940-R3085) [[2]](diffhunk://#diff-730c47f94eb96db20cebc969a039f59d09516ddab45c86feb8b12b14bc1fb1afR3021-R3107)
* Introduced a new endpoint `/api/v1/silver/soroban/ttl/resolve` to compute the ledger-key hash for a contract and key (or key type) server-side, and fetch the corresponding TTL entry. This removes the need for clients to manually marshal XDR or compute hashes. [[1]](diffhunk://#diff-563b7ef3ceae35a7a1b6899481fc8e5c36403d4cea6bacb1626775a5c7ed782fL2940-R3085) [[2]](diffhunk://#diff-214f23d2e60bf880ae59db0bede09cde7244c0a2a1c146cf7abc2bd5ef85c72eR1-R81) [[3]](diffhunk://#diff-a91035908e5bff135f28f9851a3d9a7224b66028e5bcbc2403519052abd9b286R71)

**TTL Normalization and Data Improvements:**

* Added normalization helpers to ensure TTL entries always reflect expiration and ledgers remaining relative to the current ledger, regardless of stored values. This prevents stale or incorrect TTL status.
* Expanded the `TTLEntry` struct to include `contract_id` and `durability` fields, populated when joining against contract data.

**Testing and Validation:**

* Added unit tests for TTL normalization logic to ensure correct handling of expired and non-expired entries.

**Summary of most important changes:**

**API and Handler Enhancements**
- Expanded `/api/v1/silver/soroban/ttl` to support contract-wide queries with pagination, and improved parameter validation.
- Added `/api/v1/silver/soroban/ttl/resolve` endpoint for server-side TTL resolution by contract/key. [[1]](diffhunk://#diff-563b7ef3ceae35a7a1b6899481fc8e5c36403d4cea6bacb1626775a5c7ed782fL2940-R3085) [[2]](diffhunk://#diff-214f23d2e60bf880ae59db0bede09cde7244c0a2a1c146cf7abc2bd5ef85c72eR1-R81) [[3]](diffhunk://#diff-a91035908e5bff135f28f9851a3d9a7224b66028e5bcbc2403519052abd9b286R71)

**Backend and Data Layer**
- Implemented `GetTTLByContract` in `UnifiedDuckDBReader` to efficiently fetch TTL entries for all storage keys of a contract, joining TTL and contract data tables, with cursor-based pagination.
- Updated `TTLEntry` and `TTLFilters` structs to include `contract_id`, `durability`, and filtering by contract.

**Normalization and Testing**
- Added normalization helpers for TTL entries and comprehensive unit tests to ensure TTL status is always current. [[1]](diffhunk://#diff-563b7ef3ceae35a7a1b6899481fc8e5c36403d4cea6bacb1626775a5c7ed782fR32-R45) [[2]](diffhunk://#diff-390654d1e42baa3b925a2c3a860cb12f77532c90fc3e02ec891304d05f34a810R1-R33)