### PR TITLE
Feature/tmosley/defi positions

### DIFF
--- a/obsrvr-lake/docs/defi-position-processor-design.md
+++ b/obsrvr-lake/docs/defi-position-processor-design.md
@@ -1,0 +1,922 @@
+# DeFi Position Processor Design
+
+## Purpose
+
+This document describes where the DeFi computation service should live, how it should work, and how a first complete implementation can be delivered using **Soroswap** as the reference protocol.
+
+The intent is to separate:
+
+1. **Obsrvr Lake as the data platform and serving substrate**
+2. **A dedicated DeFi computation service** that derives normalized DeFi state from Obsrvr Lake inputs
+3. **Product-facing APIs/services** that consume this normalized state
+
+This aligns with the current direction of the DeFi Positions API foundation:
+
+- `serving.sv_defi_*` tables hold normalized DeFi state
+- `stellar-query-api` exposes read endpoints over those tables
+- the missing piece is the service that computes and maintains that state
+
+---
+
+## Role of Obsrvr Lake vs. the DeFi Processor
+
+### Obsrvr Lake should provide
+
+- protocol registry data
+- protocol contract-role mapping
+- silver-layer contract calls/events/state inputs
+- current serving tables for normalized DeFi state
+- low-latency query API access over that state
+
+### The DeFi processor should provide
+
+- protocol-specific market discovery
+- protocol-specific position calculation
+- current user exposure aggregation
+- protocol status/freshness/degraded-mode computation
+- optional historical snapshots
+
+### A downstream product-facing service may still provide
+
+- customer-facing auth and onboarding
+- wallet linking / account resolution UX
+- product-level caching and SLOs
+- polished documentation / SDKs / examples
+
+---
+
+## Recommended Service Placement
+
+The DeFi computation logic should live as a **new standalone service** inside the Obsrvr Lake monorepo.
+
+### Recommended path
+
+```text
+obsrvr-lake/
+  defi-position-processor/
+```
+
+### Why it should be standalone
+
+A dedicated service keeps DeFi computation separate from:
+
+- `stellar-query-api` read concerns
+- generic `serving-projection-processor` concerns
+- lower-level silver transformation concerns
+
+This is the cleanest boundary because DeFi computation is likely to become:
+
+- protocol-adapter heavy
+- stateful
+- valuation-heavy
+- operationally distinct
+- expensive to backfill and reconcile
+
+---
+
+## Proposed Directory Layout
+
+```text
+obsrvr-lake/
+  defi-position-processor/
+    go/
+      main.go
+      config.go
+      db.go
+      checkpoint_store.go
+      runner.go
+      health.go
+
+      adapters/
+        adapter.go
+        soroswap/
+          adapter.go
+          discovery.go
+          positions.go
+          valuation.go
+          parser.go
+
+      models/
+        registry.go
+        market.go
+        position.go
+        totals.go
+        status.go
+
+      readers/
+        silver_reader.go
+        serving_reader.go
+        pricing_reader.go
+
+      writers/
+        serving_writer.go
+
+      jobs/
+        discovery.go
+        incremental.go
+        reconcile.go
+        snapshot.go
+
+    config.yaml.example
+    Dockerfile
+    Makefile
+```
+
+---
+
+## Data Flow
+
+The processor should consume Obsrvr Lake data and write normalized DeFi state back into serving tables.
+
+```text
+Stellar ledgers
+  ↓
+steller-postgres-ingester / silver-realtime-transformer
+  ↓
+stellar_hot / silver_hot / silver cold
+  ↓
+defi-position-processor
+  ↓
+serving.sv_defi_markets_current
+serving.sv_defi_positions_current
+serving.sv_defi_position_components_current
+serving.sv_defi_user_totals_current
+serving.sv_defi_protocol_status
+  ↓
+stellar-query-api
+  ↓
+gateway.withobsrvr.com / downstream products
+```
+
+---
+
+## Inputs and Outputs
+
+## Inputs
+
+### Registry / serving inputs
+
+- `serving.sv_defi_protocols`
+- `serving.sv_defi_protocol_contracts`
+
+### Silver / semantic inputs
+
+Depending on protocol, the processor may read from:
+
+- `contract_invocations_raw`
+- contract events tables
+- `contract_data_current`
+- token / asset metadata
+- liquidity pool / account balance / trustline-like state
+- semantic or explorer-enriched contract views when useful
+
+### Pricing inputs
+
+Ideally:
+
+- `serving.sv_defi_prices_current`
+
+Interim options may include protocol-local price derivation, but long term pricing should be normalized.
+
+## Outputs
+
+The processor should write to:
+
+- `serving.sv_defi_markets_current`
+- `serving.sv_defi_positions_current`
+- `serving.sv_defi_position_components_current`
+- `serving.sv_defi_user_totals_current`
+- `serving.sv_defi_protocol_status`
+
+Optional snapshot outputs:
+
+- `serving.sv_defi_user_totals_history`
+- `serving.sv_defi_position_history`
+
+---
+
+## Processing Modes
+
+The processor should support four operational modes.
+
+## 1. Discovery
+
+Purpose:
+
+- discover markets/pools/vaults for each supported protocol
+- refresh market metadata
+- populate `sv_defi_markets_current`
+
+## 2. Incremental current-state computation
+
+Purpose:
+
+- process newly-available ledgers since the last checkpoint
+- identify impacted users, positions, and markets
+- recompute current normalized state
+- upsert serving tables
+
+## 3. Reconciliation / backfill
+
+Purpose:
+
+- rebuild state after bugs, schema changes, or drift
+- recompute by protocol, market, user, or ledger range
+- validate incremental correctness
+
+## 4. Snapshotting
+
+Purpose:
+
+- periodically write compact historical snapshots
+- support portfolio history and position history endpoints
+
+---
+
+## Recommended Computation Model
+
+Use a **registry-driven, adapter-based, impacted-entity recomputation model**.
+
+### Why
+
+This model is more robust than trying to maintain every value as a pure diff stream.
+
+### Core idea
+
+1. detect new protocol-relevant activity
+2. identify impacted entities
+   - markets
+   - owner addresses
+3. recompute those entities from canonical current state
+4. replace/upsert the normalized current rows
+
+### Advantages
+
+- easier to reason about correctness
+- easier to backfill and reconcile
+- safer for DeFi math and protocol-specific semantics
+- more tolerant of replay and repair workflows
+
+---
+
+## Adapter Model
+
+Each protocol should implement a common adapter interface.
+
+### Conceptual interface
+
+```go
+type ProtocolAdapter interface {
+    ProtocolID() string
+
+    DiscoverMarkets(ctx context.Context, deps AdapterDeps) ([]DefiMarketRecord, error)
+
+    AffectedEntitiesFromLedgerRange(
+        ctx context.Context,
+        deps AdapterDeps,
+        fromLedger, toLedger int64,
+    ) (*AffectedEntities, error)
+
+    RecomputeMarkets(
+        ctx context.Context,
+        deps AdapterDeps,
+        marketIDs []string,
+    ) ([]DefiMarketRecord, error)
+
+    RecomputeUserPositions(
+        ctx context.Context,
+        deps AdapterDeps,
+        ownerAddress string,
+    ) ([]DefiPositionRecord, []DefiPositionComponentRecord, error)
+
+    ComputeUserTotals(
+        ctx context.Context,
+        deps AdapterDeps,
+        ownerAddress string,
+        positions []DefiPositionRecord,
+    ) (*DefiUserTotalsRecord, error)
+
+    ComputeProtocolStatus(ctx context.Context, deps AdapterDeps) (*DefiProtocolStatusRecord, error)
+}
+```
+
+### Shared dependencies
+
+```go
+type AdapterDeps struct {
+    Silver   SilverReader
+    Serving  ServingReader
+    Pricing  PricingReader
+    Writer   ServingWriter
+    Clock    func() time.Time
+}
+```
+
+---
+
+## Checkpointing
+
+The processor should maintain checkpoints, ideally one per protocol.
+
+### Recommended storage
+
+Use `serving.sv_projection_checkpoints` with names like:
+
+- `defi-position-processor:soroswap`
+- `defi-position-processor:aquarius`
+- `defi-position-processor:blend`
+
+### Why per-protocol checkpoints
+
+This allows:
+
+- one protocol to backfill or degrade without blocking all others
+- easier debugging and replay
+- protocol-specific operational visibility
+
+---
+
+## Incremental Processing Cycle
+
+Each incremental cycle should:
+
+1. load latest available silver ledger
+2. load checkpoint per protocol
+3. process the unhandled ledger range
+4. detect impacted entities
+5. recompute markets and users
+6. upsert serving rows
+7. update protocol status
+8. advance checkpoint
+
+### Pseudocode
+
+```go
+func (r *Runner) RunCycle(ctx context.Context) error {
+    latest, err := r.silver.LatestLedger(ctx)
+    if err != nil { return err }
+
+    for _, adapter := range r.adapters {
+        cp, err := r.checkpoints.Load(ctx, adapter.ProtocolID())
+        if err != nil { return err }
+
+        if cp >= latest {
+            continue
+        }
+
+        affected, err := adapter.AffectedEntitiesFromLedgerRange(ctx, r.deps, cp+1, latest)
+        if err != nil {
+            r.statusWriter.MarkProtocolDegraded(ctx, adapter.ProtocolID(), err)
+            continue
+        }
+
+        if len(affected.MarketIDs) > 0 {
+            markets, err := adapter.RecomputeMarkets(ctx, r.deps, keys(affected.MarketIDs))
+            if err != nil { return err }
+            if err := r.writer.UpsertMarkets(ctx, markets); err != nil { return err }
+        }
+
+        for _, owner := range keys(affected.OwnerAddresses) {
+            positions, components, err := adapter.RecomputeUserPositions(ctx, r.deps, owner)
+            if err != nil { return err }
+
+            if err := r.writer.ReplaceUserProtocolPositions(ctx, adapter.ProtocolID(), owner, positions, components); err != nil {
+                return err
+            }
+
+            totals, err := adapter.ComputeUserTotals(ctx, r.deps, owner, positions)
+            if err != nil { return err }
+
+            if err := r.writer.UpsertUserTotals(ctx, totals); err != nil {
+                return err
+            }
+        }
+
+        status, err := adapter.ComputeProtocolStatus(ctx, r.deps)
+        if err == nil {
+            _ = r.writer.UpsertProtocolStatus(ctx, status)
+        }
+
+        if err := r.checkpoints.Save(ctx, adapter.ProtocolID(), latest); err != nil {
+            return err
+        }
+    }
+
+    return nil
+}
+```
+
+---
+
+# Soroswap Complete Example
+
+Soroswap is a strong first implementation target because it already has real contract IDs and observable contract invocation behavior in current indexed data.
+
+## Known Soroswap testnet contracts
+
+### Router
+
+- `CCJUD55AG6W5HAI5LRVNKAE5WDP5XGZBUDS5WNTIVDU7O264UZZE7BRD`
+
+Observed functions in live data:
+
+- `swap_exact_tokens_for_tokens`
+- `add_liquidity`
+- `remove_liquidity`
+
+### Factory
+
+- `CDP3HMUH6SMS3S7NPGNDJLULCOXXEPSHY4JKUKMBNQMATHDHWXRRJTBY`
+
+### Reviewed hashes
+
+- pair hash: `8447525edd62f72ffaf52136358034657ea0511a8fec1cd0ebde649f86cca464`
+- factory hash: `86285a9234d3f0d687eaf88efe8d5d72172b38c9a86624c9934c0cbf2aff2993`
+- router hash: `4b95bbf9caec2c6e00c786f53c5f392c2fcdb8435ac0a862ab5e0645eb65824c`
+- token hash: `263d165c1a1bf5a0dddbd0f21744a55cd8cacedf96ade78f53c570df11490e46`
+
+---
+
+## Soroswap Support Scope (Phase 1)
+
+Model Soroswap initially as:
+
+- protocol category: `amm`
+- current market type: `lp_pool`
+- user exposure type: `lp_position`
+
+### Included in first slice
+
+- pool discovery
+- LP position computation
+- LP reserve-share valuation
+- user totals aggregation
+- protocol status
+
+### Deferred initially
+
+- claimable rewards
+- fee attribution / advanced return decomposition
+- sophisticated historical PnL
+- broader route analytics beyond what is needed for market and position maintenance
+
+---
+
+## Soroswap Discovery
+
+Purpose:
+
+- discover and maintain Soroswap pool markets in `sv_defi_markets_current`
+
+### Possible discovery strategies
+
+#### Strategy A: pool creation / init calls
+
+Use observed functions like:
+
+- `init_standard_pool`
+- `init_stableswap_pool`
+
+#### Strategy B: pool inference from call graphs
+
+Observe router calls into pool contracts during:
+
+- `add_liquidity`
+- `remove_liquidity`
+- swaps
+
+#### Strategy C: join to existing pool/asset metadata
+
+Use existing Obsrvr Lake liquidity pool and asset metadata if it can be mapped to Soroswap pools.
+
+### Soroswap market row shape
+
+Each discovered pool becomes a normalized market row:
+
+```text
+market_id        = "soroswap:<pool_contract_id>"
+protocol_id      = "soroswap"
+market_type      = "lp_pool"
+market_address   = <pool_contract_id>
+router_address   = <router_contract_id>
+input_asset_1    = token A
+input_asset_2    = token B
+as_of_ledger     = current ledger
+as_of_time       = current time
+```
+
+### Example market record
+
+```json
+{
+  "market_id": "soroswap:CPOOL...",
+  "protocol_id": "soroswap",
+  "market_type": "lp_pool",
+  "market_address": "CPOOL...",
+  "router_address": "CCJUD55AG6W5HAI5LRVNKAE5WDP5XGZBUDS5WNTIVDU7O264UZZE7BRD",
+  "input_asset_1": {"symbol":"USDC"},
+  "input_asset_2": {"symbol":"XLM"},
+  "tvl_value_usd": "128420.8821000000",
+  "metadata_json": {
+    "factory_contract_id": "CDP3HMUH6SMS3S7NPGNDJLULCOXXEPSHY4JKUKMBNQMATHDHWXRRJTBY",
+    "pool_contract_id": "CPOOL..."
+  }
+}
+```
+
+---
+
+## Soroswap Incremental Impact Detection
+
+For each unprocessed ledger range, scan Soroswap-relevant contract activity.
+
+### Relevant functions
+
+- `swap_exact_tokens_for_tokens`
+- `add_liquidity`
+- `remove_liquidity`
+
+### Affected entities model
+
+```go
+type AffectedEntities struct {
+    MarketIDs      map[string]struct{}
+    OwnerAddresses map[string]struct{}
+}
+```
+
+### Impact rules
+
+#### `add_liquidity`
+
+- affected market = target pool
+- affected owner = caller / LP holder
+
+#### `remove_liquidity`
+
+- affected market = target pool
+- affected owner = caller / LP holder
+
+#### `swap_exact_tokens_for_tokens`
+
+- affected market(s) = pools touched
+- initial simple implementation: recompute market only
+- user recomputation can remain limited to liquidity add/remove events in Phase 1
+
+### Practical Phase 1 simplification
+
+- recompute users only for liquidity add/remove
+- recompute markets for liquidity add/remove + swaps
+
+This keeps the first implementation tractable and correct enough for a strong vertical slice.
+
+---
+
+## Soroswap Position Model
+
+A Soroswap LP position is modeled as:
+
+- owner address
+- pool contract
+- current LP share ownership
+- reserve-share decomposition into underlying assets
+
+### Position identity
+
+```text
+position_id = "soroswap:lp:<owner_address>:<pool_contract_id>"
+```
+
+### Position type
+
+```text
+position_type = "lp_position"
+```
+
+### Market link
+
+```text
+market_id = "soroswap:<pool_contract_id>"
+```
+
+---
+
+## Soroswap Position Computation
+
+To compute a user's LP position, the adapter needs:
+
+- owner LP share balance `s`
+- total pool shares `S`
+- reserve A `RA`
+- reserve B `RB`
+- price A
+- price B
+
+### Reserve-share formulas
+
+If the user owns `s / S` of the pool:
+
+- `ownerA = (s / S) * RA`
+- `ownerB = (s / S) * RB`
+
+Value:
+
+- `valueA = ownerA * priceA`
+- `valueB = ownerB * priceB`
+- `current_value = valueA + valueB`
+
+### Phase 1 normalized values
+
+For an LP position:
+
+- `deposit_value = current_value`
+- `borrowed_value = 0`
+- `net_value = current_value`
+- `health_factor = null`
+- `risk_status = null`
+
+---
+
+## Soroswap Position Components
+
+Each LP position should write two component rows.
+
+### Component A
+
+```text
+component_type = "lp_leg"
+asset          = token A
+amount         = ownerA
+value          = valueA
+price          = priceA
+```
+
+### Component B
+
+```text
+component_type = "lp_leg"
+asset          = token B
+amount         = ownerB
+value          = valueB
+price          = priceB
+```
+
+Rewards can be added later as:
+
+```text
+component_type = "reward"
+```
+
+---
+
+## Example Soroswap Position Row
+
+```json
+{
+  "position_id": "soroswap:lp:GABC...:CPOOL...",
+  "protocol_id": "soroswap",
+  "position_type": "lp_position",
+  "status": "open",
+  "owner_address": "GABC...",
+  "market_id": "soroswap:CPOOL...",
+  "market_address": "CPOOL...",
+  "quote_currency": "USD",
+  "share_amount": "125.1234567",
+  "deposit_value": "482.1172000000",
+  "borrowed_value": "0",
+  "current_value": "482.1172000000",
+  "net_value": "482.1172000000",
+  "protocol_state_json": {
+    "pool_share_fraction": "0.00428192",
+    "pool_contract_id": "CPOOL..."
+  },
+  "valuation_json": {
+    "method": "reserve_share"
+  },
+  "as_of_ledger": 123456,
+  "as_of_time": "2026-01-01T00:00:00Z"
+}
+```
+
+---
+
+## Soroswap User Totals
+
+For a user with only Soroswap LP positions:
+
+- `total_value = sum(current_value)`
+- `total_deposit_value = sum(deposit_value)`
+- `total_borrowed_value = 0`
+- `net_value = total_value`
+- `open_position_count = number of open positions`
+- `protocol_count = 1`
+
+### Example `by_protocol_json`
+
+```json
+[
+  {
+    "protocol_id": "soroswap",
+    "total_value": "482.1172",
+    "total_deposit_value": "482.1172",
+    "total_borrowed_value": "0",
+    "net_value": "482.1172",
+    "position_count": 1
+  }
+]
+```
+
+---
+
+## Soroswap Protocol Status
+
+The adapter should update `serving.sv_defi_protocol_status` based on:
+
+- successful market discovery
+- successful market/position recomputation
+- availability of required pool inputs
+- availability and freshness of pricing inputs
+- checkpoint progress
+
+### Example status outcomes
+
+- `ok`
+  - pool discovery working
+  - pricing available
+  - processing advancing
+
+- `degraded`
+  - some pools unresolved
+  - some price inputs missing or stale
+
+- `halted`
+  - required source data not readable
+
+- `backfill`
+  - adapter explicitly rebuilding historical/current state
+
+---
+
+## Soroswap Processing Cycle Example
+
+### On startup
+
+1. load Soroswap registry rows
+2. discover markets
+3. upsert `sv_defi_markets_current`
+4. initialize checkpoint if missing
+
+### On each incremental cycle
+
+1. load Soroswap checkpoint
+2. read new ledgers since checkpoint
+3. detect impacted markets and users
+4. recompute markets
+5. recompute impacted users' positions
+6. recompute impacted users' totals
+7. update protocol status
+8. advance checkpoint
+
+---
+
+## Writer Semantics
+
+The writer should support a protocol-scoped replace/upsert pattern.
+
+### Example
+
+For `ReplaceUserProtocolPositions(protocolID, ownerAddress, positions, components)`:
+
+1. delete current rows for that protocol + owner
+2. insert recomputed current rows
+3. delete old component rows for those positions
+4. insert recomputed component rows
+
+This avoids stale partial state and simplifies correctness.
+
+---
+
+## Service Health Surface
+
+The processor should expose a health endpoint with at least:
+
+- latest observed silver ledger
+- per-protocol processed checkpoint
+- last successful cycle time
+- degraded protocols
+- discovered market count
+- current position count
+
+### Example
+
+```json
+{
+  "status": "ok",
+  "latest_silver_ledger": 123456,
+  "protocols": {
+    "soroswap": {
+      "last_processed_ledger": 123455,
+      "markets_discovered": 14,
+      "positions_current": 832,
+      "status": "ok"
+    }
+  }
+}
+```
+
+---
+
+## Deployment Model
+
+The processor should deploy like other Obsrvr Lake services.
+
+### Suggested Nomad job
+
+- `defi-position-processor.nomad`
+
+### Config inputs
+
+- silver DB connection
+- serving DB connection
+- price source config
+- enabled protocol list
+- tick/trigger mode
+- reconciliation controls
+- snapshot interval
+
+### Triggering
+
+#### Near-term
+
+- periodic polling every N seconds
+
+#### Longer-term
+
+- gRPC / event-driven trigger, similar to other processors in the stack
+
+---
+
+## Recommended First Milestone
+
+### Milestone: Soroswap LP positions end-to-end
+
+Deliver:
+
+- new `defi-position-processor` service skeleton
+- Soroswap adapter
+- market discovery
+- LP position computation
+- component decomposition
+- user totals computation
+- protocol status updates
+- read visibility through existing `stellar-query-api` DeFi endpoints
+
+### Exclusions for milestone 1
+
+- rewards
+- advanced fee/PnL decomposition
+- multi-protocol aggregation beyond Soroswap
+- deep history analytics beyond optional simple snapshots
+
+This would provide a real vertical slice and prove the architecture with live chain-backed data.
+
+---
+
+## Recommended Next Protocols After Soroswap
+
+### Aquarius
+
+Likely next easiest fit:
+
+- router + pool discovery
+- LP / stableswap reserve-share logic
+- market and totals support similar to Soroswap
+
+### Blend
+n
+More complex and better suited after the AMM slice is proven:
+
+- lending deposits
+- borrowing positions
+- collateral / debt decomposition
+- health factor computation
+- backstop pool semantics
+
+---
+
+## Summary
+
+A dedicated `defi-position-processor` should live inside the Obsrvr Lake monorepo as a standalone service that:
+
+- reads protocol registry + silver-layer inputs
+- uses protocol-specific adapters
+- computes normalized markets, positions, components, totals, and protocol status
+- writes them into `serving.sv_defi_*`
+- supports incremental updates, reconciliation, and optional snapshotting
+
+Soroswap is the recommended first complete example because:
+
+- real registry contracts are already known
+- live invocation behavior is already observable
+- LP reserve-share valuation is tractable
+- it provides a strong end-to-end proof point for the DeFi Positions architecture

--- a/obsrvr-lake/docs/defi-positions-implementation.md
+++ b/obsrvr-lake/docs/defi-positions-implementation.md
@@ -1,0 +1,420 @@
+# DeFi Positions API — Concrete Implementation Plan
+
+## Goal
+
+Add a DeFi positions layer to Obsrvr Lake that supports:
+
+- protocol registry and market registry
+- normalized user positions across supported Stellar DeFi protocols
+- aggregate exposure summaries
+- historical position and exposure charts
+- protocol health / freshness / degraded-mode reporting
+
+This document defines:
+
+1. actual SQL migration files for `serving.sv_defi_*` tables
+2. OpenAPI-style endpoint definitions for `/api/v1/semantic/defi/*`
+3. processor and rollout requirements for integrating this into Obsrvr Lake
+
+---
+
+## Deliverables added in this repo
+
+### SQL migrations
+
+Location:
+
+- `serving-projection-processor/migrations/001_create_sv_defi_protocol_registry.sql`
+- `serving-projection-processor/migrations/002_create_sv_defi_markets_current.sql`
+- `serving-projection-processor/migrations/003_create_sv_defi_positions_current.sql`
+- `serving-projection-processor/migrations/004_create_sv_defi_totals_and_history.sql`
+- `serving-projection-processor/migrations/005_create_sv_defi_prices_and_status.sql`
+
+### OpenAPI spec
+
+Location:
+
+- `stellar-query-api/docs/defi-openapi.yaml`
+
+---
+
+## What is being added to Obsrvr Lake
+
+### New serving tables
+
+The implementation adds the following new serving-layer tables:
+
+- `serving.sv_defi_protocols`
+- `serving.sv_defi_protocol_contracts`
+- `serving.sv_defi_markets_current`
+- `serving.sv_defi_positions_current`
+- `serving.sv_defi_position_components_current`
+- `serving.sv_defi_user_totals_current`
+- `serving.sv_defi_user_totals_history`
+- `serving.sv_defi_position_history`
+- `serving.sv_defi_prices_current`
+- `serving.sv_defi_protocol_status`
+
+### New API surface
+
+Planned endpoints:
+
+- `GET /api/v1/semantic/defi/protocols`
+- `GET /api/v1/semantic/defi/markets`
+- `GET /api/v1/semantic/defi/status`
+- `GET /api/v1/semantic/defi/exposure`
+- `GET /api/v1/semantic/defi/positions`
+- `GET /api/v1/semantic/defi/positions/{position_id}`
+- `GET /api/v1/semantic/defi/positions/history`
+
+---
+
+## Why a new DeFi protocol registry is needed
+
+Existing registry-like tables in Obsrvr Lake are useful but do not solve DeFi aggregation:
+
+- `token_registry` answers token metadata questions
+- `contract_registry` answers contract identity questions
+- `event_classification_rules` answers event semantics questions
+- `semantic_entities_contracts` answers observed contract-type questions
+
+A DeFi positions system needs a different type of registry:
+
+- which protocols are supported
+- which contracts belong to a protocol deployment
+- what role each contract plays
+- which adapter should decode positions
+- what pricing and health models apply
+- how degraded status should be reported
+
+That is why this design introduces an explicit `sv_defi_protocols` + `sv_defi_protocol_contracts` registry rather than overloading the existing registries.
+
+---
+
+## Serving table roles
+
+### 1. `sv_defi_protocols`
+Canonical protocol registry.
+
+Use cases:
+- `/semantic/defi/protocols`
+- protocol capability checks
+- adapter dispatch
+- status labeling
+
+### 2. `sv_defi_protocol_contracts`
+Maps protocol IDs to contract IDs and contract roles.
+
+Use cases:
+- pool discovery
+- market registry construction
+- protocol ownership of contracts
+- enrichment of explorer / DeFi responses
+
+### 3. `sv_defi_markets_current`
+Current protocol markets/pools/vaults.
+
+Use cases:
+- `/semantic/defi/markets`
+- valuation and health inputs
+- market metadata lookup during position computation
+
+### 4. `sv_defi_positions_current`
+Current normalized user positions.
+
+Use cases:
+- `/semantic/defi/positions`
+- `/semantic/defi/positions/{position_id}`
+- wallet dashboards
+- protocol user summaries
+
+### 5. `sv_defi_position_components_current`
+Breaks complex positions into legs/components.
+
+Use cases:
+- detailed position view
+- collateral/debt decomposition
+- LP reserve-share decomposition
+- rewards display
+
+### 6. `sv_defi_user_totals_current`
+Pre-aggregated user summary table.
+
+Use cases:
+- `/semantic/defi/exposure`
+- low-latency account summary surfaces
+
+### 7. `sv_defi_user_totals_history`
+Exposure history by time bucket.
+
+Use cases:
+- user portfolio charts
+- trend analysis
+
+### 8. `sv_defi_position_history`
+Per-position history snapshots.
+
+Use cases:
+- charting individual positions
+- risk / liquidation retrospectives
+
+### 9. `sv_defi_prices_current`
+Normalized price layer for valuation.
+
+Use cases:
+- current value calculation
+- health factor computation
+- stale-price detection
+
+### 10. `sv_defi_protocol_status`
+Operational/freshness state for the DeFi layer.
+
+Use cases:
+- `/semantic/defi/status`
+- degraded mode reporting
+- monitoring and alerting
+
+---
+
+## SQL migration application
+
+### Recommended execution order
+
+Apply in this order:
+
+1. `001_create_sv_defi_protocol_registry.sql`
+2. `002_create_sv_defi_markets_current.sql`
+3. `003_create_sv_defi_positions_current.sql`
+4. `004_create_sv_defi_totals_and_history.sql`
+5. `005_create_sv_defi_prices_and_status.sql`
+
+### Example manual application
+
+```bash
+MIGS=obsrvr-lake/serving-projection-processor/migrations
+export PGHOST="<your-postgres-host>"
+export PGPORT=5432
+export PGUSER="<your-postgres-user>"
+export PGPASSWORD="$SILVER_HOT_PASSWORD"
+PSQL_SILVER="psql -d silver_hot"
+
+$PSQL_SILVER -f "$MIGS/001_create_sv_defi_protocol_registry.sql"
+$PSQL_SILVER -f "$MIGS/002_create_sv_defi_markets_current.sql"
+$PSQL_SILVER -f "$MIGS/003_create_sv_defi_positions_current.sql"
+$PSQL_SILVER -f "$MIGS/004_create_sv_defi_totals_and_history.sql"
+$PSQL_SILVER -f "$MIGS/005_create_sv_defi_prices_and_status.sql"
+```
+
+### Notes
+
+All migrations are written to be safely re-runnable:
+
+- `CREATE SCHEMA IF NOT EXISTS`
+- `CREATE TABLE IF NOT EXISTS`
+- `CREATE INDEX IF NOT EXISTS`
+
+---
+
+## API design summary
+
+### `GET /api/v1/semantic/defi/protocols`
+Returns supported DeFi protocols from `sv_defi_protocols`.
+
+### `GET /api/v1/semantic/defi/markets`
+Returns current markets from `sv_defi_markets_current`.
+
+### `GET /api/v1/semantic/defi/status`
+Returns status/freshness from `sv_defi_protocol_status`.
+
+### `GET /api/v1/semantic/defi/exposure?address=...`
+Returns one-row aggregate exposure from `sv_defi_user_totals_current`.
+
+### `GET /api/v1/semantic/defi/positions?address=...`
+Returns normalized positions from `sv_defi_positions_current`.
+Can optionally join components or aggregate summary.
+
+### `GET /api/v1/semantic/defi/positions/{position_id}`
+Returns one position plus its rows from `sv_defi_position_components_current`.
+
+### `GET /api/v1/semantic/defi/positions/history?address=...`
+Returns history from `sv_defi_user_totals_history`.
+
+Full OpenAPI-style definitions are in:
+
+- `stellar-query-api/docs/defi-openapi.yaml`
+
+---
+
+## Processor architecture to add
+
+### 1. DeFi protocol registry loader
+
+Responsibilities:
+- seed and maintain `sv_defi_protocols`
+- seed and maintain `sv_defi_protocol_contracts`
+- allow manual and code-managed configuration
+
+Suggested implementation:
+- start with code- or file-backed seed data
+- later add admin mutation endpoints if needed
+
+### 2. DeFi position processor
+
+New service recommended:
+- `defi-position-processor/`
+
+Responsibilities:
+- consume protocol registry
+- resolve protocol contracts and markets
+- read from silver/serving/index sources
+- compute user positions incrementally
+- upsert `sv_defi_positions_current`
+- upsert `sv_defi_position_components_current`
+- upsert `sv_defi_user_totals_current`
+- update `sv_defi_protocol_status`
+
+Inputs likely needed:
+- `contract_events`
+- `contract_data_current`
+- token balances
+- market metadata
+- price inputs
+
+### 3. DeFi history snapshotter
+
+Responsibilities:
+- periodically snapshot current totals and positions into history tables
+
+Outputs:
+- `sv_defi_user_totals_history`
+- `sv_defi_position_history`
+
+### 4. DeFi pricing input service/processor
+
+Responsibilities:
+- produce `sv_defi_prices_current`
+- mark stale/degraded sources
+- support multiple source types:
+  - oracle
+  - DEX TWAP
+  - fixed/manual
+  - derived price
+
+---
+
+## Suggested processor interfaces
+
+Each supported protocol should have an adapter implementing a common interface.
+
+Suggested conceptual interface:
+
+```go
+type ProtocolAdapter interface {
+    ProtocolID() string
+    DiscoverMarkets(ctx context.Context) ([]Market, error)
+    ResolveUserPositions(ctx context.Context, address string) ([]Position, error)
+    ComputePositionComponents(ctx context.Context, p Position) ([]Component, error)
+    ComputeValuation(ctx context.Context, p Position, prices PriceBook) (Valuation, error)
+    ComputeRisk(ctx context.Context, p Position, prices PriceBook) (RiskMetrics, error)
+}
+```
+
+Initial protocol candidates:
+- Blend
+- Aquarius
+- Soroswap
+- FxDAO
+
+---
+
+## Data freshness and degraded mode
+
+Every DeFi API response should include:
+
+- `as_of_ledger`
+- `as_of_time`
+- `freshness_seconds`
+- `data_status`
+
+Recommended `data_status` values:
+- `ok`
+- `degraded`
+- `stale_prices`
+- `partial_protocol_coverage`
+- `backfill_in_progress`
+- `protocol_unavailable`
+
+This requirement is specifically important for the target product because low-latency/high-availability is part of the evaluation criteria.
+
+---
+
+## Integration points in `stellar-query-api`
+
+Recommended additions:
+
+- `go/handlers_defi.go`
+- `go/routes_defi.go`
+- reader methods on top of `serving.sv_defi_*` tables
+- optional analyst guide additions for DeFi examples
+
+The OpenAPI spec in `stellar-query-api/docs/defi-openapi.yaml` can be used as the basis for handler annotations and documentation.
+
+---
+
+## Recommended implementation order
+
+### Phase 1 — registry and current-state foundation
+- apply SQL migrations
+- seed `sv_defi_protocols`
+- seed `sv_defi_protocol_contracts`
+- implement current market + current position processor
+- add `/semantic/defi/protocols`
+- add `/semantic/defi/markets`
+- add `/semantic/defi/status`
+
+### Phase 2 — user-facing portfolio endpoints
+- populate `sv_defi_positions_current`
+- populate `sv_defi_position_components_current`
+- populate `sv_defi_user_totals_current`
+- add `/semantic/defi/exposure`
+- add `/semantic/defi/positions`
+- add `/semantic/defi/positions/{position_id}`
+
+### Phase 3 — historical analytics
+- snapshot `sv_defi_user_totals_history`
+- snapshot `sv_defi_position_history`
+- add `/semantic/defi/positions/history`
+
+---
+
+## What this design intentionally does not do yet
+
+This document defines the data model and API contract, but does not yet implement:
+
+- protocol-specific adapter code
+- handler code in `stellar-query-api`
+- price-source selection strategy implementation
+- backfill jobs for historical DeFi state
+- admin APIs for mutating protocol registry data
+
+Those should be implemented after agreeing on the schema and endpoint contract in this document.
+
+---
+
+## Summary
+
+This implementation adds a dedicated DeFi registry and serving layer to Obsrvr Lake instead of trying to overload the existing token/contract registries.
+
+It gives Obsrvr Lake a concrete path to support:
+
+- production DeFi user portfolio APIs
+- multi-protocol normalized position queries
+- historical exposure charts
+- degraded/freshness-aware responses
+
+The concrete artifacts in this repo now include:
+
+- actual SQL migration files for all proposed `serving.sv_defi_*` tables
+- an OpenAPI-style spec for the `/api/v1/semantic/defi/*` endpoints
+
+These should be treated as the contract for the next implementation phase.

--- a/obsrvr-lake/docs/defi-seed-example.sql
+++ b/obsrvr-lake/docs/defi-seed-example.sql
@@ -1,0 +1,143 @@
+-- Example bootstrap SQL for the DeFi registry.
+--
+-- This file is intentionally documentation / bootstrap material, not a mandatory
+-- migration. Review and replace placeholder metadata before using in an
+-- environment that serves real traffic.
+
+INSERT INTO serving.sv_defi_protocols (
+    protocol_id,
+    network,
+    display_name,
+    slug,
+    category,
+    status,
+    adapter_name,
+    pricing_model,
+    health_model,
+    supports_history,
+    supports_rewards,
+    supports_health_factor,
+    website_url,
+    docs_url,
+    source,
+    verified,
+    config_json
+) VALUES
+    (
+        'blend',
+        'testnet',
+        'Blend',
+        'blend',
+        'lending',
+        'active',
+        'blend_v1',
+        'oracle_spot',
+        'health_factor',
+        true,
+        true,
+        true,
+        'https://blend.capital/',
+        'https://docs.blend.capital/',
+        'manual',
+        false,
+        '{"note":"bootstrap example; contract/admin metadata reviewed for current testnet rollout","admin_account":"GCL4PUHEJX3ZCPTYB6RKPYK5NQDCGXVRATGX37MMH2MWA23KQEIHTKU5","seed_confidence":"user_verified"}'::jsonb
+    ),
+    (
+        'aquarius',
+        'testnet',
+        'Aquarius',
+        'aquarius',
+        'amm',
+        'active',
+        'aquarius_v1',
+        'reserve_share',
+        null,
+        true,
+        false,
+        false,
+        'https://aqua.network/',
+        'https://docs.aqua.network/',
+        'manual',
+        false,
+        '{"note":"bootstrap example; router observed in contract_invocations_raw","seed_confidence":"observed_in_contract_invocations"}'::jsonb
+    ),
+    (
+        'soroswap',
+        'testnet',
+        'Soroswap',
+        'soroswap',
+        'amm',
+        'active',
+        'soroswap_v1',
+        'reserve_share',
+        null,
+        true,
+        false,
+        false,
+        'https://soroswap.finance/',
+        'https://docs.soroswap.finance/',
+        'manual',
+        false,
+        '{"note":"bootstrap example; Soroswap hashes reviewed for current testnet rollout","factory_wasm_hash":"86285a9234d3f0d687eaf88efe8d5d72172b38c9a86624c9934c0cbf2aff2993","router_wasm_hash":"4b95bbf9caec2c6e00c786f53c5f392c2fcdb8435ac0a862ab5e0645eb65824c","pair_wasm_hash":"8447525edd62f72ffaf52136358034657ea0511a8fec1cd0ebde649f86cca464","token_wasm_hash":"263d165c1a1bf5a0dddbd0f21744a55cd8cacedf96ade78f53c570df11490e46","seed_confidence":"user_verified"}'::jsonb
+    ),
+    (
+        'fxdao',
+        'testnet',
+        'FxDAO',
+        'fxdao',
+        'stable',
+        'active',
+        'fxdao_v1',
+        'oracle_spot',
+        'health_factor',
+        true,
+        true,
+        true,
+        null,
+        null,
+        'manual',
+        false,
+        '{"note":"bootstrap example; protocol row retained but contract ids still pending verification","status_note":"contract ids pending verification"}'::jsonb
+    )
+ON CONFLICT (protocol_id) DO UPDATE SET
+    display_name = EXCLUDED.display_name,
+    slug = EXCLUDED.slug,
+    category = EXCLUDED.category,
+    status = EXCLUDED.status,
+    adapter_name = EXCLUDED.adapter_name,
+    pricing_model = EXCLUDED.pricing_model,
+    health_model = EXCLUDED.health_model,
+    supports_history = EXCLUDED.supports_history,
+    supports_rewards = EXCLUDED.supports_rewards,
+    supports_health_factor = EXCLUDED.supports_health_factor,
+    website_url = EXCLUDED.website_url,
+    docs_url = EXCLUDED.docs_url,
+    source = EXCLUDED.source,
+    verified = EXCLUDED.verified,
+    config_json = EXCLUDED.config_json,
+    updated_at = now();
+
+-- Contract rows below reflect currently-identified testnet contracts.
+-- Blend values were supplied externally and are retained as unverified until
+-- independently confirmed from indexed chain metadata. Aquarius and Soroswap
+-- router entries were observed in live contract_invocations_raw.
+INSERT INTO serving.sv_defi_protocol_contracts (
+    protocol_id,
+    contract_id,
+    role,
+    is_active,
+    verified,
+    source,
+    metadata_json
+) VALUES
+    ('blend', 'CAPBMXIQTICKWFPWFDJWMAKBXBPJZUKLNONQH3MLPLLBKQ643CYN5PRW', 'market', true, false, 'manual', '{"seed_confidence":"user_verified_not_observed_in_current_index"}'::jsonb),
+    ('blend', 'CCBTMXJW4BCEX2YCCOHQ5RX2C5CS6U4FZAYXFAL7LCB7GSAIHYVW4QLE', 'oracle', true, false, 'manual', '{"seed_confidence":"user_verified_not_observed_in_current_index"}'::jsonb),
+    ('aquarius', 'CBCFTQSPDBAIZ6R6PJQKSQWKNKWH2QIV3I4J72SHWBIK3ADRRAM5A6GD', 'router', true, true, 'manual', '{"observed_functions":["swap_chained","swap_chained_strict_receive","init_standard_pool","init_stableswap_pool"]}'::jsonb),
+    ('soroswap', 'CCJUD55AG6W5HAI5LRVNKAE5WDP5XGZBUDS5WNTIVDU7O264UZZE7BRD', 'router', true, true, 'manual', '{"observed_functions":["swap_exact_tokens_for_tokens","add_liquidity","remove_liquidity"]}'::jsonb),
+    ('soroswap', 'CDP3HMUH6SMS3S7NPGNDJLULCOXXEPSHY4JKUKMBNQMATHDHWXRRJTBY', 'factory', true, false, 'manual', '{"seed_confidence":"user_verified"}'::jsonb)
+ON CONFLICT (protocol_id, contract_id, role) DO UPDATE SET
+    is_active = EXCLUDED.is_active,
+    verified = EXCLUDED.verified,
+    source = EXCLUDED.source,
+    metadata_json = EXCLUDED.metadata_json,
+    updated_at = now();

--- a/obsrvr-lake/serving-projection-processor/go/config.go
+++ b/obsrvr-lake/serving-projection-processor/go/config.go
@@ -65,6 +65,7 @@ type ProjectorsConfig struct {
 	EventsRecent         ProjectorConfig `yaml:"events_recent"`
 	ExplorerEventsRecent ProjectorConfig `yaml:"explorer_events_recent"`
 	ContractCallsRecent  ProjectorConfig `yaml:"contract_calls_recent"`
+	TxReceipts           ProjectorConfig `yaml:"tx_receipts"`
 }
 
 type ProjectorConfig struct {
@@ -128,6 +129,12 @@ func LoadConfig(path string) (*Config, error) {
 	}
 	if cfg.Projectors.ContractCallsRecent.BatchSize <= 0 {
 		cfg.Projectors.ContractCallsRecent.BatchSize = 1
+	}
+	if cfg.Projectors.TxReceipts.BatchSize <= 0 {
+		// tx_receipts does 4 sub-queries per batch and builds JSON blobs in
+		// memory; 256 is a safe starting point. Raise if throughput is fine
+		// and memory headroom allows.
+		cfg.Projectors.TxReceipts.BatchSize = 256
 	}
 	if cfg.Health.Port == 0 {
 		cfg.Health.Port = 8097

--- a/obsrvr-lake/serving-projection-processor/go/main.go
+++ b/obsrvr-lake/serving-projection-processor/go/main.go
@@ -51,6 +51,9 @@ func buildProjectors(cfg *Config, bronze, silver, serving *pgxpool.Pool, checkpo
 	if cfg.Projectors.ContractCallsRecent.Enabled {
 		projectors = append(projectors, NewContractCallsRecentProjector("testnet", cfg.Projectors.ContractCallsRecent.BatchSize, silver, serving, checkpoints))
 	}
+	if cfg.Projectors.TxReceipts.Enabled {
+		projectors = append(projectors, NewTxReceiptsProjector("testnet", cfg.Projectors.TxReceipts.BatchSize, bronze, silver, serving, checkpoints))
+	}
 	return projectors
 }
 

--- a/obsrvr-lake/serving-projection-processor/go/schema/serving_schema.sql
+++ b/obsrvr-lake/serving-projection-processor/go/schema/serving_schema.sql
@@ -581,6 +581,309 @@ create table if not exists serving.sv_rebuild_jobs (
 );
 
 -- ============================================================
+-- 6. DEFI SERVING TABLES
+-- ============================================================
+
+create table if not exists serving.sv_defi_protocols (
+    protocol_id                    text primary key,
+    network                        text not null,
+    display_name                   text not null,
+    slug                           text not null,
+    version                        text,
+    category                       text not null,
+    status                         text not null default 'active',
+    adapter_name                   text not null,
+    pricing_model                  text not null,
+    health_model                   text,
+    supports_history               boolean not null default true,
+    supports_rewards               boolean not null default false,
+    supports_health_factor         boolean not null default false,
+    website_url                    text,
+    docs_url                       text,
+    icon_url                       text,
+    config_json                    jsonb not null default '{}'::jsonb,
+    source                         text not null default 'manual',
+    verified                       boolean not null default false,
+    last_updated_ledger            bigint,
+    last_updated_at                timestamptz,
+    created_at                     timestamptz not null default now(),
+    updated_at                     timestamptz not null default now(),
+    constraint sv_defi_protocols_status_chk check (status in ('active', 'degraded', 'paused', 'retired'))
+);
+
+create unique index if not exists idx_sv_defi_protocols_network_slug
+    on serving.sv_defi_protocols (network, slug);
+create index if not exists idx_sv_defi_protocols_category
+    on serving.sv_defi_protocols (category);
+create index if not exists idx_sv_defi_protocols_status
+    on serving.sv_defi_protocols (status);
+
+create table if not exists serving.sv_defi_protocol_contracts (
+    protocol_id                    text not null references serving.sv_defi_protocols(protocol_id) on delete cascade,
+    contract_id                    text not null,
+    role                           text not null,
+    market_id                      text,
+    is_active                      boolean not null default true,
+    verified                       boolean not null default false,
+    source                         text not null default 'manual',
+    metadata_json                  jsonb not null default '{}'::jsonb,
+    first_seen_ledger              bigint,
+    last_seen_ledger               bigint,
+    created_at                     timestamptz not null default now(),
+    updated_at                     timestamptz not null default now(),
+    primary key (protocol_id, contract_id, role)
+);
+
+create index if not exists idx_sv_defi_protocol_contracts_contract
+    on serving.sv_defi_protocol_contracts (contract_id);
+create index if not exists idx_sv_defi_protocol_contracts_role
+    on serving.sv_defi_protocol_contracts (protocol_id, role, is_active);
+create index if not exists idx_sv_defi_protocol_contracts_market
+    on serving.sv_defi_protocol_contracts (market_id) where market_id is not null;
+
+create table if not exists serving.sv_defi_markets_current (
+    market_id                      text primary key,
+    protocol_id                    text not null references serving.sv_defi_protocols(protocol_id) on delete cascade,
+    market_type                    text not null,
+    market_address                 text,
+    pool_address                   text,
+    router_address                 text,
+    oracle_contract_id             text,
+    input_asset_1_type             text,
+    input_asset_1_code             text,
+    input_asset_1_issuer           text,
+    input_asset_1_contract_id      text,
+    input_asset_1_symbol           text,
+    input_asset_1_decimals         integer,
+    input_asset_2_type             text,
+    input_asset_2_code             text,
+    input_asset_2_issuer           text,
+    input_asset_2_contract_id      text,
+    input_asset_2_symbol           text,
+    input_asset_2_decimals         integer,
+    share_asset_contract_id        text,
+    debt_asset_contract_id         text,
+    collateral_asset_contract_id   text,
+    oracle_source                  text,
+    is_active                      boolean not null default true,
+    metadata_json                  jsonb not null default '{}'::jsonb,
+    tvl_value_usd                  numeric(38,10),
+    total_deposit_value_usd        numeric(38,10),
+    total_borrowed_value_usd       numeric(38,10),
+    total_rewards_value_usd        numeric(38,10),
+    apr_deposit                    numeric(20,10),
+    apr_borrow                     numeric(20,10),
+    apr_rewards                    numeric(20,10),
+    as_of_ledger                   bigint not null,
+    as_of_time                     timestamptz not null,
+    updated_at                     timestamptz not null default now()
+);
+
+create index if not exists idx_sv_defi_markets_protocol
+    on serving.sv_defi_markets_current (protocol_id, market_type, is_active);
+create index if not exists idx_sv_defi_markets_market_address
+    on serving.sv_defi_markets_current (market_address) where market_address is not null;
+create index if not exists idx_sv_defi_markets_pool_address
+    on serving.sv_defi_markets_current (pool_address) where pool_address is not null;
+create index if not exists idx_sv_defi_markets_tvl
+    on serving.sv_defi_markets_current (tvl_value_usd desc);
+
+create table if not exists serving.sv_defi_positions_current (
+    position_id                    text primary key,
+    protocol_id                    text not null references serving.sv_defi_protocols(protocol_id) on delete cascade,
+    protocol_version               text,
+    position_type                  text not null,
+    status                         text not null,
+    owner_address                  text not null,
+    account_address                text,
+    related_address                text,
+    market_id                      text references serving.sv_defi_markets_current(market_id) on delete set null,
+    market_address                 text,
+    position_key_hash              text,
+    underlying_asset_type          text,
+    underlying_asset_code          text,
+    underlying_asset_issuer        text,
+    underlying_asset_contract_id   text,
+    underlying_symbol              text,
+    underlying_decimals            integer,
+    quote_currency                 text not null default 'USD',
+    deposit_amount                 numeric(38,18),
+    borrow_amount                  numeric(38,18),
+    share_amount                   numeric(38,18),
+    claimable_reward_amount        numeric(38,18),
+    deposit_value                  numeric(38,10),
+    borrowed_value                 numeric(38,10),
+    current_value                  numeric(38,10),
+    net_value                      numeric(38,10),
+    current_return_value           numeric(38,10),
+    current_return_percent         numeric(20,10),
+    claimable_rewards_value        numeric(38,10),
+    health_factor                  numeric(20,10),
+    ltv                            numeric(20,10),
+    collateral_ratio               numeric(20,10),
+    liquidation_threshold          numeric(20,10),
+    risk_status                    text,
+    opened_at                      timestamptz,
+    opened_ledger                  bigint,
+    closed_at                      timestamptz,
+    closed_ledger                  bigint,
+    protocol_state_json            jsonb not null default '{}'::jsonb,
+    valuation_json                 jsonb not null default '{}'::jsonb,
+    source_json                    jsonb not null default '{}'::jsonb,
+    as_of_ledger                   bigint not null,
+    as_of_time                     timestamptz not null,
+    last_updated_ledger            bigint not null,
+    last_updated_at                timestamptz not null,
+    updated_at                     timestamptz not null default now()
+);
+
+create index if not exists idx_sv_defi_positions_owner
+    on serving.sv_defi_positions_current (owner_address, status, as_of_time desc);
+create index if not exists idx_sv_defi_positions_owner_protocol
+    on serving.sv_defi_positions_current (owner_address, protocol_id, status);
+create index if not exists idx_sv_defi_positions_market
+    on serving.sv_defi_positions_current (market_id) where market_id is not null;
+create index if not exists idx_sv_defi_positions_risk
+    on serving.sv_defi_positions_current (risk_status, health_factor);
+create index if not exists idx_sv_defi_positions_current_value
+    on serving.sv_defi_positions_current (current_value desc);
+
+create table if not exists serving.sv_defi_position_components_current (
+    component_id                   text primary key,
+    position_id                    text not null references serving.sv_defi_positions_current(position_id) on delete cascade,
+    protocol_id                    text not null references serving.sv_defi_protocols(protocol_id) on delete cascade,
+    component_type                 text not null,
+    asset_type                     text,
+    asset_code                     text,
+    asset_issuer                   text,
+    asset_contract_id              text,
+    symbol                         text,
+    decimals                       integer,
+    amount                         numeric(38,18),
+    value                          numeric(38,10),
+    price                          numeric(38,18),
+    price_source                   text,
+    metadata_json                  jsonb not null default '{}'::jsonb,
+    as_of_ledger                   bigint not null,
+    as_of_time                     timestamptz not null,
+    updated_at                     timestamptz not null default now()
+);
+
+create index if not exists idx_sv_defi_position_components_position
+    on serving.sv_defi_position_components_current (position_id, component_type);
+create index if not exists idx_sv_defi_position_components_protocol
+    on serving.sv_defi_position_components_current (protocol_id, component_type);
+
+create table if not exists serving.sv_defi_user_totals_current (
+    owner_address                  text not null,
+    quote_currency                 text not null default 'USD',
+    total_value                    numeric(38,10) not null default 0,
+    total_deposit_value            numeric(38,10) not null default 0,
+    total_borrowed_value           numeric(38,10) not null default 0,
+    net_value                      numeric(38,10) not null default 0,
+    total_claimable_rewards_value  numeric(38,10) not null default 0,
+    open_position_count            integer not null default 0,
+    protocol_count                 integer not null default 0,
+    lowest_health_factor           numeric(20,10),
+    positions_at_risk              integer not null default 0,
+    by_protocol_json               jsonb not null default '[]'::jsonb,
+    source_json                    jsonb not null default '{}'::jsonb,
+    as_of_ledger                   bigint not null,
+    as_of_time                     timestamptz not null,
+    updated_at                     timestamptz not null default now(),
+    primary key (owner_address, quote_currency)
+);
+
+create index if not exists idx_sv_defi_user_totals_current_value
+    on serving.sv_defi_user_totals_current (total_value desc);
+create index if not exists idx_sv_defi_user_totals_health
+    on serving.sv_defi_user_totals_current (lowest_health_factor);
+
+create table if not exists serving.sv_defi_user_totals_history (
+    owner_address                  text not null,
+    bucket_start                   timestamptz not null,
+    interval                       text not null,
+    quote_currency                 text not null default 'USD',
+    total_value                    numeric(38,10) not null default 0,
+    total_deposit_value            numeric(38,10) not null default 0,
+    total_borrowed_value           numeric(38,10) not null default 0,
+    net_value                      numeric(38,10) not null default 0,
+    total_claimable_rewards_value  numeric(38,10) not null default 0,
+    open_position_count            integer not null default 0,
+    as_of_ledger                   bigint,
+    as_of_time                     timestamptz,
+    primary key (owner_address, interval, quote_currency, bucket_start)
+);
+
+create index if not exists idx_sv_defi_user_totals_history_lookup
+    on serving.sv_defi_user_totals_history (owner_address, interval, bucket_start desc);
+
+create table if not exists serving.sv_defi_position_history (
+    position_id                    text not null,
+    bucket_start                   timestamptz not null,
+    interval                       text not null,
+    quote_currency                 text not null default 'USD',
+    protocol_id                    text not null,
+    owner_address                  text not null,
+    status                         text,
+    deposit_value                  numeric(38,10),
+    borrowed_value                 numeric(38,10),
+    current_value                  numeric(38,10),
+    net_value                      numeric(38,10),
+    current_return_value           numeric(38,10),
+    health_factor                  numeric(20,10),
+    risk_status                    text,
+    as_of_ledger                   bigint,
+    as_of_time                     timestamptz,
+    primary key (position_id, interval, quote_currency, bucket_start)
+);
+
+create index if not exists idx_sv_defi_position_history_owner
+    on serving.sv_defi_position_history (owner_address, interval, bucket_start desc);
+create index if not exists idx_sv_defi_position_history_protocol
+    on serving.sv_defi_position_history (protocol_id, interval, bucket_start desc);
+
+create table if not exists serving.sv_defi_prices_current (
+    asset_key                      text not null,
+    quote_currency                 text not null default 'USD',
+    asset_type                     text,
+    asset_code                     text,
+    asset_issuer                   text,
+    asset_contract_id              text,
+    symbol                         text,
+    price                          numeric(38,18) not null,
+    price_source                   text not null,
+    confidence                     numeric(20,10),
+    source_timestamp               timestamptz,
+    source_ledger                  bigint,
+    stale_after_seconds            integer,
+    status                         text not null default 'ok',
+    metadata_json                  jsonb not null default '{}'::jsonb,
+    updated_at                     timestamptz not null default now(),
+    primary key (asset_key, quote_currency)
+);
+
+create index if not exists idx_sv_defi_prices_status
+    on serving.sv_defi_prices_current (status, updated_at desc);
+create index if not exists idx_sv_defi_prices_contract
+    on serving.sv_defi_prices_current (asset_contract_id) where asset_contract_id is not null;
+
+create table if not exists serving.sv_defi_protocol_status (
+    protocol_id                    text primary key references serving.sv_defi_protocols(protocol_id) on delete cascade,
+    status                         text not null,
+    reason                         text,
+    last_successful_ledger         bigint,
+    last_successful_time           timestamptz,
+    freshness_seconds              integer,
+    source_divergence              boolean not null default false,
+    source_json                    jsonb not null default '{}'::jsonb,
+    updated_at                     timestamptz not null default now()
+);
+
+create index if not exists idx_sv_defi_protocol_status_status
+    on serving.sv_defi_protocol_status (status, updated_at desc);
+
+-- ============================================================
 -- OPTIONAL VIEW EXAMPLES
 -- ============================================================
 
@@ -609,3 +912,55 @@ select
 from serving.sv_assets_current a
 join serving.sv_asset_stats_current s using (asset_key)
 order by s.volume_24h desc nulls last;
+
+-- ---------------------------------------------------------------------------
+-- sv_tx_receipts
+-- ---------------------------------------------------------------------------
+-- Pre-materialized "transaction receipt" rows for Prism's tx detail page.
+-- One row per transaction containing everything the page needs, so the
+-- frontend does a single PK lookup instead of 5–7 parallel queries that each
+-- hit cold DuckLake. Previous per-page cost: ~5s (bounded by /diffs). New
+-- target: <50ms.
+--
+-- All derived fields are stored as JSONB so the projection can evolve without
+-- requiring migrations, and Prism can select just the slice it renders.
+create table if not exists serving.sv_tx_receipts (
+    tx_hash                text primary key,
+    ledger_sequence        bigint not null,
+    created_at             timestamptz not null,
+    source_account         text,
+    successful             boolean not null,
+    operation_count        integer,
+
+    -- Core payload — the union of /full + /semantic + /effects + /diffs,
+    -- each as a JSON blob. Prism can pick what it needs per section.
+    full_json              jsonb,   -- operations, metadata, fee info
+    semantic_json          jsonb,   -- tx_type + summary + actor classification
+    effects_json           jsonb,   -- compact effect list (op_idx, type, account, amount, asset)
+    diffs_json             jsonb,   -- per-account balance changes
+    events_json            jsonb,   -- token-transfer events scoped to this tx
+
+    -- Denormalized for cheap filtering/linking
+    involved_contracts     text[],  -- for Prism to build links to /smart-wallet/{c}
+    involved_accounts      text[],  -- same, for account pages
+    primary_contract_id    text,
+    tx_type                text,
+
+    -- Materialization bookkeeping
+    materialized_at        timestamptz not null default now(),
+    source_version         text not null default 'v1'
+);
+
+create index if not exists sv_tx_receipts_ledger_idx
+    on serving.sv_tx_receipts (ledger_sequence desc);
+create index if not exists sv_tx_receipts_created_idx
+    on serving.sv_tx_receipts (created_at desc);
+create index if not exists sv_tx_receipts_source_idx
+    on serving.sv_tx_receipts (source_account, created_at desc) where source_account is not null;
+create index if not exists sv_tx_receipts_primary_contract_idx
+    on serving.sv_tx_receipts (primary_contract_id, created_at desc) where primary_contract_id is not null;
+-- GIN on array columns so "txs involving contract X" becomes a single index scan
+create index if not exists sv_tx_receipts_contracts_gin_idx
+    on serving.sv_tx_receipts using gin (involved_contracts);
+create index if not exists sv_tx_receipts_accounts_gin_idx
+    on serving.sv_tx_receipts using gin (involved_accounts);

--- a/obsrvr-lake/serving-projection-processor/go/transaction_summary_enricher.go
+++ b/obsrvr-lake/serving-projection-processor/go/transaction_summary_enricher.go
@@ -302,6 +302,19 @@ func summarizeSingleProjectorOp(op projectorDecodedOperation, contracts []string
 			InvolvedContracts: contracts,
 			Transfer:          &TransferDetail{Asset: asset, Amount: amount, From: op.SourceAccount, To: stringValue(op.Destination)},
 		}
+	case "change_trust":
+		if asset != "" && asset != "XLM" {
+			return &TxSummary{
+				Description:       fmt.Sprintf("Added trustline for %s", asset),
+				Type:              "change_trust",
+				InvolvedContracts: contracts,
+			}
+		}
+		return &TxSummary{
+			Description:       "Updated trustline",
+			Type:              "change_trust",
+			InvolvedContracts: contracts,
+		}
 	}
 
 	if op.IsSorobanOp && op.FunctionName != nil && *op.FunctionName != "" {

--- a/obsrvr-lake/serving-projection-processor/go/tx_receipts_projector.go
+++ b/obsrvr-lake/serving-projection-processor/go/tx_receipts_projector.go
@@ -1,0 +1,820 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"math/big"
+	"sort"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/withObsrvr/obsrvr-lake/serving-projection-processor/txview"
+)
+
+// TxReceiptsProjector materializes per-transaction "receipt" rows into
+// serving.sv_tx_receipts. Purpose: collapse Prism's 5–7 parallel calls
+// (/full, /semantic, /effects, /diffs, /events, etc.) on a transaction
+// detail page into a single serving-layer PK lookup.
+//
+// Reads from silver_hot:
+//   - enriched_history_operations   → op list + tx-level metadata
+//   - effects                       → per-op effects (for effects_json + diffs derivation)
+//   - token_transfers_raw           → token events (events_json)
+//   - semantic_activities           → tx_type + description
+//
+// Writes one row per (distinct transaction_hash) in the watermark window.
+//
+// Checkpoint: last ledger_sequence successfully projected. Same pattern as
+// the other *_recent projectors.
+type TxReceiptsProjector struct {
+	network     string
+	batchSize   int
+	bronzePool  *pgxpool.Pool
+	silverPool  *pgxpool.Pool
+	servingPool *pgxpool.Pool
+	checkpoints *CheckpointStore
+}
+
+func NewTxReceiptsProjector(network string, batchSize int, bronzePool, silverPool, servingPool *pgxpool.Pool, checkpoints *CheckpointStore) *TxReceiptsProjector {
+	return &TxReceiptsProjector{
+		network:     network,
+		batchSize:   batchSize,
+		bronzePool:  bronzePool,
+		silverPool:  silverPool,
+		servingPool: servingPool,
+		checkpoints: checkpoints,
+	}
+}
+
+func (p *TxReceiptsProjector) Name() string { return "tx_receipts" }
+
+func (p *TxReceiptsProjector) SourceHighWatermark(ctx context.Context) (int64, error) {
+	var wm int64
+	err := p.silverPool.QueryRow(ctx, `SELECT COALESCE(MAX(ledger_sequence), 0) FROM enriched_history_operations`, pgx.QueryExecModeSimpleProtocol).Scan(&wm)
+	if err != nil {
+		return 0, fmt.Errorf("query tx receipts watermark: %w", err)
+	}
+	return wm, nil
+}
+
+type txMeta struct {
+	TxHash                       string
+	LedgerSequence               int64
+	CreatedAt                    time.Time
+	SourceAccount                string
+	Successful                   bool
+	Fee                          int64
+	MaxFee                       *int64
+	AccountSequence              *int64
+	SorobanResourcesInstructions *int64
+	SorobanResourcesReadBytes    *int64
+	SorobanResourcesWriteBytes   *int64
+}
+
+func (p *TxReceiptsProjector) RunOnce(ctx context.Context) (RunStats, error) {
+	checkpoint, err := p.checkpoints.Load(ctx, p.Name(), p.network)
+	if err != nil {
+		return RunStats{}, err
+	}
+
+	// Always process complete ledgers before advancing the checkpoint.
+	// Limiting directly by tx hash count and then checkpointing by ledger can
+	// skip receipts permanently whenever a later-ledger tx lands in the same
+	// batch as unprocessed txs from earlier ledgers.
+	candidates, err := p.loadCandidates(ctx, checkpoint)
+	if err != nil {
+		return RunStats{}, err
+	}
+	if len(candidates) == 0 {
+		return RunStats{Checkpoint: checkpoint}, nil
+	}
+
+	// 2. For each candidate tx, load the per-tx data in parallel-by-nature
+	//    via 4 batched queries keyed by tx_hash IN (...). Build the JSON
+	//    blobs in-memory and UPSERT.
+	hashes := make([]string, len(candidates))
+	for i, c := range candidates {
+		hashes[i] = c.TxHash
+	}
+
+	operations, err := p.loadOperations(ctx, hashes)
+	if err != nil {
+		return RunStats{}, err
+	}
+	effects, err := p.loadEffects(ctx, hashes)
+	if err != nil {
+		return RunStats{}, err
+	}
+	tokenEvents, err := p.loadTokenEvents(ctx, hashes)
+	if err != nil {
+		return RunStats{}, err
+	}
+	txDetails, err := p.loadTransactionDetails(ctx, hashes)
+	if err != nil {
+		return RunStats{}, err
+	}
+	semanticByTx, err := p.loadSemantic(ctx, hashes)
+	if err != nil {
+		return RunStats{}, err
+	}
+
+	// 3. Assemble + UPSERT in a single transaction for atomicity
+	tx, err := p.servingPool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return RunStats{}, fmt.Errorf("begin tx-receipts tx: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	maxLedger := checkpoint
+	var lastCreated *time.Time
+	applied := 0
+	for _, c := range candidates {
+		ops := operations[c.TxHash]
+		effs := effects[c.TxHash]
+		toks := tokenEvents[c.TxHash]
+		detail := txDetails[c.TxHash]
+		if detail.Fee != 0 {
+			c.Fee = detail.Fee
+		}
+		if detail.MaxFee != nil {
+			c.MaxFee = detail.MaxFee
+		}
+		if detail.AccountSequence != nil {
+			c.AccountSequence = detail.AccountSequence
+		}
+		if detail.SorobanResourcesInstructions != nil {
+			c.SorobanResourcesInstructions = detail.SorobanResourcesInstructions
+		}
+		if detail.SorobanResourcesReadBytes != nil {
+			c.SorobanResourcesReadBytes = detail.SorobanResourcesReadBytes
+		}
+		if detail.SorobanResourcesWriteBytes != nil {
+			c.SorobanResourcesWriteBytes = detail.SorobanResourcesWriteBytes
+		}
+
+		summary := buildReceiptSummary(ops, toks)
+		fallbackSummary := semanticByTx[c.TxHash]
+		if (summary.Type == "" || summary.Type == "unknown") && fallbackSummary.Type != "" {
+			summary = fallbackSummary
+		}
+		semanticPayload := buildReceiptSemanticPayload(c, ops, toks, summary)
+
+		diffs := deriveBalanceDiffs(effs)
+		involvedContracts := collectContractIDs(ops, toks)
+		involvedAccounts := collectAccountIDs(ops, effs, toks, c.SourceAccount)
+		primaryContract := firstOrNil(involvedContracts)
+		txType := summary.Type
+
+		fullJSON, _ := json.Marshal(map[string]any{
+			"tx_hash":                        c.TxHash,
+			"ledger_sequence":                c.LedgerSequence,
+			"created_at":                     c.CreatedAt,
+			"source_account":                 nullable(c.SourceAccount),
+			"successful":                     c.Successful,
+			"fee":                            c.Fee,
+			"max_fee":                        c.MaxFee,
+			"account_sequence":               c.AccountSequence,
+			"soroban_resources_instructions": c.SorobanResourcesInstructions,
+			"soroban_resources_read_bytes":   c.SorobanResourcesReadBytes,
+			"soroban_resources_write_bytes":  c.SorobanResourcesWriteBytes,
+			"summary":                        summary,
+			"operations":                     receiptOpsToTxViewOps(ops),
+			"events":                         receiptEventsToTxViewEvents(toks),
+		})
+		semanticJSON, _ := json.Marshal(semanticPayload)
+		effectsJSON, _ := json.Marshal(effs)
+		diffsJSON, _ := json.Marshal(diffs)
+		eventsJSON, _ := json.Marshal(toks)
+
+		ct := c.CreatedAt
+		_, err := tx.Exec(ctx, `
+			INSERT INTO serving.sv_tx_receipts (
+				tx_hash, ledger_sequence, created_at, source_account, successful,
+				operation_count, full_json, semantic_json, effects_json, diffs_json,
+				events_json, involved_contracts, involved_accounts,
+				primary_contract_id, tx_type, materialized_at
+			) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15, now())
+			ON CONFLICT (tx_hash) DO UPDATE SET
+				ledger_sequence     = EXCLUDED.ledger_sequence,
+				created_at          = EXCLUDED.created_at,
+				source_account      = EXCLUDED.source_account,
+				successful          = EXCLUDED.successful,
+				operation_count     = EXCLUDED.operation_count,
+				full_json           = EXCLUDED.full_json,
+				semantic_json       = EXCLUDED.semantic_json,
+				effects_json        = EXCLUDED.effects_json,
+				diffs_json          = EXCLUDED.diffs_json,
+				events_json         = EXCLUDED.events_json,
+				involved_contracts  = EXCLUDED.involved_contracts,
+				involved_accounts   = EXCLUDED.involved_accounts,
+				primary_contract_id = EXCLUDED.primary_contract_id,
+				tx_type             = EXCLUDED.tx_type,
+				materialized_at     = now()
+		`,
+			c.TxHash, c.LedgerSequence, c.CreatedAt, nullable(c.SourceAccount), c.Successful,
+			len(ops), fullJSON, semanticJSON, effectsJSON, diffsJSON,
+			eventsJSON, involvedContracts, involvedAccounts,
+			primaryContract, nullable(txType),
+		)
+		if err != nil {
+			return RunStats{}, fmt.Errorf("upsert tx receipt %s: %w", c.TxHash, err)
+		}
+		if c.LedgerSequence > maxLedger {
+			maxLedger = c.LedgerSequence
+		}
+		lastCreated = &ct
+		applied++
+	}
+
+	if err := p.checkpoints.Save(ctx, tx, p.Name(), p.network, maxLedger, lastCreated); err != nil {
+		return RunStats{}, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return RunStats{}, fmt.Errorf("commit tx-receipts tx: %w", err)
+	}
+
+	log.Printf("projector=%s network=%s applied=%d checkpoint=%d", p.Name(), p.network, applied, maxLedger)
+	return RunStats{RowsApplied: int64(applied), Checkpoint: maxLedger}, nil
+}
+
+// ---- Data shapes held only in memory while building the row ----------------
+
+type receiptOperation struct {
+	Index         int     `json:"operation_index"`
+	Type          int     `json:"type"`
+	TypeName      string  `json:"type_name,omitempty"`
+	SourceAccount *string `json:"source_account,omitempty"`
+	ContractID    *string `json:"contract_id,omitempty"`
+	FunctionName  *string `json:"function_name,omitempty"`
+	Destination   *string `json:"destination,omitempty"`
+	AssetCode     *string `json:"asset_code,omitempty"`
+	Amount        *string `json:"amount,omitempty"`
+	IsSoroban     bool    `json:"is_soroban,omitempty"`
+}
+
+type receiptEffect struct {
+	OperationIndex int     `json:"operation_index"`
+	EffectIndex    int     `json:"effect_index"`
+	EffectType     string  `json:"effect_type"`
+	AccountID      *string `json:"account_id,omitempty"`
+	AssetCode      *string `json:"asset_code,omitempty"`
+	AssetIssuer    *string `json:"asset_issuer,omitempty"`
+	Amount         *string `json:"amount,omitempty"`
+}
+
+type receiptTokenEvent struct {
+	EventID        string  `json:"event_id"`
+	LedgerSequence int64   `json:"ledger_sequence"`
+	TxHash         string  `json:"tx_hash"`
+	ClosedAt       string  `json:"closed_at"`
+	EventType      string  `json:"event_type"`
+	From           *string `json:"from,omitempty"`
+	To             *string `json:"to,omitempty"`
+	ContractID     *string `json:"contract_id,omitempty"`
+	AssetCode      *string `json:"asset_code,omitempty"`
+	AssetIssuer    *string `json:"asset_issuer,omitempty"`
+	Amount         *string `json:"amount,omitempty"`
+	SourceType     string  `json:"source_type"`
+	OperationType  *int32  `json:"operation_type,omitempty"`
+	EventIndex     int     `json:"event_index"`
+}
+
+type balanceDiff struct {
+	Account string `json:"account"`
+	Asset   string `json:"asset"`
+	Delta   string `json:"delta"` // signed string (+/- amount)
+}
+
+// ---- Per-column loaders (batched by tx_hash IN (...)) ----------------------
+//
+// Each loader keys the returned map by tx_hash. Missing keys just mean no
+// rows for that tx, which is fine — the projector emits empty arrays.
+
+func (p *TxReceiptsProjector) loadOperations(ctx context.Context, hashes []string) (map[string][]receiptOperation, error) {
+	rows, err := p.silverPool.Query(ctx, `
+		SELECT transaction_hash, operation_index, type, source_account, contract_id,
+		       function_name, destination, asset_code, amount, is_soroban_op
+		  FROM enriched_history_operations
+		 WHERE transaction_hash = ANY($1)
+		 ORDER BY transaction_hash, operation_index
+	`, pgx.QueryExecModeSimpleProtocol, hashes)
+	if err != nil {
+		return nil, fmt.Errorf("query tx-receipt operations: %w", err)
+	}
+	defer rows.Close()
+	out := make(map[string][]receiptOperation, len(hashes))
+	for rows.Next() {
+		var hash string
+		var op receiptOperation
+		var soroban *bool
+		if err := rows.Scan(&hash, &op.Index, &op.Type, &op.SourceAccount, &op.ContractID,
+			&op.FunctionName, &op.Destination, &op.AssetCode, &op.Amount, &soroban); err != nil {
+			return nil, err
+		}
+		op.TypeName = operationTypeName(int32(op.Type))
+		if soroban != nil {
+			op.IsSoroban = *soroban
+		}
+		out[hash] = append(out[hash], op)
+	}
+	return out, rows.Err()
+}
+
+func (p *TxReceiptsProjector) loadEffects(ctx context.Context, hashes []string) (map[string][]receiptEffect, error) {
+	rows, err := p.silverPool.Query(ctx, `
+		SELECT transaction_hash, operation_index, effect_index, effect_type_string,
+		       account_id, asset_code, asset_issuer, amount
+		  FROM effects
+		 WHERE transaction_hash = ANY($1)
+		 ORDER BY transaction_hash, operation_index, effect_index
+	`, pgx.QueryExecModeSimpleProtocol, hashes)
+	if err != nil {
+		return nil, fmt.Errorf("query tx-receipt effects: %w", err)
+	}
+	defer rows.Close()
+	out := make(map[string][]receiptEffect, len(hashes))
+	for rows.Next() {
+		var hash string
+		var e receiptEffect
+		if err := rows.Scan(&hash, &e.OperationIndex, &e.EffectIndex, &e.EffectType,
+			&e.AccountID, &e.AssetCode, &e.AssetIssuer, &e.Amount); err != nil {
+			return nil, err
+		}
+		out[hash] = append(out[hash], e)
+	}
+	return out, rows.Err()
+}
+
+func (p *TxReceiptsProjector) loadTokenEvents(ctx context.Context, hashes []string) (map[string][]receiptTokenEvent, error) {
+	rows, err := p.silverPool.Query(ctx, `
+		SELECT transaction_hash, ledger_sequence, timestamp, source_type, operation_type,
+		       COALESCE(event_index, -1), from_account, to_account,
+		       token_contract_id, asset_code, asset_issuer, amount::text
+		  FROM token_transfers_raw
+		 WHERE transaction_hash = ANY($1) AND transaction_successful = true
+		 ORDER BY transaction_hash, ledger_sequence, timestamp, COALESCE(event_index, -1)
+	`, pgx.QueryExecModeSimpleProtocol, hashes)
+	if err != nil {
+		return nil, fmt.Errorf("query tx-receipt token events: %w", err)
+	}
+	defer rows.Close()
+	out := make(map[string][]receiptTokenEvent, len(hashes))
+	for rows.Next() {
+		var hash string
+		var ev receiptTokenEvent
+		var ts time.Time
+		var opType *int32
+		if err := rows.Scan(&hash, &ev.LedgerSequence, &ts, &ev.SourceType, &opType, &ev.EventIndex, &ev.From, &ev.To,
+			&ev.ContractID, &ev.AssetCode, &ev.AssetIssuer, &ev.Amount); err != nil {
+			return nil, err
+		}
+		ev.TxHash = hash
+		ev.ClosedAt = ts.UTC().Format(time.RFC3339)
+		ev.OperationType = opType
+		switch {
+		case ev.From == nil && ev.To != nil:
+			ev.EventType = "mint"
+		case ev.To == nil && ev.From != nil:
+			ev.EventType = "burn"
+		default:
+			ev.EventType = "transfer"
+		}
+		ev.EventID = fmt.Sprintf("%s:%d:%d", hash, ev.LedgerSequence, ev.EventIndex)
+		out[hash] = append(out[hash], ev)
+	}
+	return out, rows.Err()
+}
+
+func (p *TxReceiptsProjector) loadSemantic(ctx context.Context, hashes []string) (map[string]txview.TxSummary, error) {
+	// semantic_activities remains a fallback-only source of summary text during
+	// resets. Canonical receipt semantics are now derived from shared txview
+	// logic so the serving projection and /semantic stay aligned.
+	rows, err := p.silverPool.Query(ctx, `
+		SELECT DISTINCT ON (transaction_hash) transaction_hash, activity_type, description
+		  FROM semantic_activities
+		 WHERE transaction_hash = ANY($1)
+		 ORDER BY transaction_hash, ledger_sequence
+	`, pgx.QueryExecModeSimpleProtocol, hashes)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "42P01" {
+			log.Printf("projector=tx_receipts semantic_activities unavailable (non-fatal): %v", err)
+			return map[string]txview.TxSummary{}, nil
+		}
+		return nil, fmt.Errorf("query tx-receipt semantic: %w", err)
+	}
+	defer rows.Close()
+	out := make(map[string]txview.TxSummary, len(hashes))
+	for rows.Next() {
+		var hash, activityType string
+		var desc *string
+		if err := rows.Scan(&hash, &activityType, &desc); err != nil {
+			return nil, err
+		}
+		out[hash] = txview.TxSummary{Type: activityType, Description: derefString(desc)}
+	}
+	return out, rows.Err()
+}
+
+func (p *TxReceiptsProjector) loadTransactionDetails(ctx context.Context, hashes []string) (map[string]txMeta, error) {
+	rows, err := p.bronzePool.Query(ctx, `
+		SELECT transaction_hash, fee_charged, max_fee, account_sequence,
+		       soroban_resources_instructions, soroban_resources_read_bytes,
+		       soroban_resources_write_bytes
+		  FROM transactions_row_v2
+		 WHERE transaction_hash = ANY($1)
+	`, pgx.QueryExecModeSimpleProtocol, hashes)
+	if err != nil {
+		return nil, fmt.Errorf("query tx-receipt transaction details: %w", err)
+	}
+	defer rows.Close()
+	out := make(map[string]txMeta, len(hashes))
+	for rows.Next() {
+		var hash string
+		var detail txMeta
+		if err := rows.Scan(&hash, &detail.Fee, &detail.MaxFee, &detail.AccountSequence,
+			&detail.SorobanResourcesInstructions, &detail.SorobanResourcesReadBytes,
+			&detail.SorobanResourcesWriteBytes); err != nil {
+			return nil, err
+		}
+		out[hash] = detail
+	}
+	return out, rows.Err()
+}
+
+// ---- Helpers --------------------------------------------------------------
+
+// deriveBalanceDiffs collapses effects into per-(account, asset) signed deltas.
+// This is the expensive aggregation previously computed on every /diffs request;
+// now done once at materialization time.
+func deriveBalanceDiffs(effs []receiptEffect) []balanceDiff {
+	type key struct{ account, asset string }
+	acc := make(map[key]*big.Rat)
+	for _, e := range effs {
+		if e.AccountID == nil || e.Amount == nil {
+			continue
+		}
+		signedAmount, ok := signedEffectAmount(e)
+		if !ok {
+			continue
+		}
+		k := key{account: *e.AccountID, asset: normalizeEffectAsset(e)}
+		if acc[k] == nil {
+			acc[k] = new(big.Rat)
+		}
+		acc[k].Add(acc[k], signedAmount)
+	}
+	out := make([]balanceDiff, 0, len(acc))
+	for k, total := range acc {
+		if total == nil || total.Sign() == 0 {
+			continue
+		}
+		out = append(out, balanceDiff{Account: k.account, Asset: k.asset, Delta: formatRatDecimal(total)})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Account != out[j].Account {
+			return out[i].Account < out[j].Account
+		}
+		if out[i].Asset != out[j].Asset {
+			return out[i].Asset < out[j].Asset
+		}
+		return out[i].Delta < out[j].Delta
+	})
+	return out
+}
+
+func signedEffectAmount(e receiptEffect) (*big.Rat, bool) {
+	if e.Amount == nil || *e.Amount == "" {
+		return nil, false
+	}
+	amt, ok := new(big.Rat).SetString(*e.Amount)
+	if !ok {
+		return nil, false
+	}
+	switch e.EffectType {
+	case "account_credited", "contract_credited":
+		return amt, true
+	case "account_debited", "contract_debited":
+		return amt.Neg(amt), true
+	default:
+		return nil, false
+	}
+}
+
+func normalizeEffectAsset(e receiptEffect) string {
+	asset := "native"
+	if e.AssetCode != nil && *e.AssetCode != "" {
+		asset = *e.AssetCode
+		if e.AssetIssuer != nil && *e.AssetIssuer != "" {
+			asset = asset + ":" + *e.AssetIssuer
+		}
+	}
+	return asset
+}
+
+func formatRatDecimal(r *big.Rat) string {
+	if r == nil {
+		return "0"
+	}
+	// Effects amounts currently arrive as decimal strings with fixed-scale
+	// formatting (e.g. 0.2900000). Preserve that representation for receipts.
+	return r.FloatString(7)
+}
+
+func collectContractIDs(ops []receiptOperation, toks []receiptTokenEvent) []string {
+	seen := make(map[string]struct{})
+	var out []string
+	add := func(s *string) {
+		if s == nil || *s == "" {
+			return
+		}
+		if _, ok := seen[*s]; ok {
+			return
+		}
+		seen[*s] = struct{}{}
+		out = append(out, *s)
+	}
+	for _, o := range ops {
+		add(o.ContractID)
+	}
+	for _, t := range toks {
+		add(t.ContractID)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func collectAccountIDs(ops []receiptOperation, effs []receiptEffect, toks []receiptTokenEvent, source string) []string {
+	seen := make(map[string]struct{})
+	var out []string
+	add := func(s *string) {
+		if s == nil || *s == "" {
+			return
+		}
+		if _, ok := seen[*s]; ok {
+			return
+		}
+		seen[*s] = struct{}{}
+		out = append(out, *s)
+	}
+	if source != "" {
+		add(&source)
+	}
+	for _, o := range ops {
+		add(o.SourceAccount)
+		add(o.Destination)
+	}
+	for _, e := range effs {
+		add(e.AccountID)
+	}
+	for _, t := range toks {
+		add(t.From)
+		add(t.To)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func (p *TxReceiptsProjector) loadCandidates(ctx context.Context, checkpoint int64) ([]txMeta, error) {
+	// Pull one extra row so we can detect whether the last ledger in the batch
+	// is only partially represented. We only checkpoint through fully included
+	// ledgers.
+	candidates, err := p.queryCandidateBatch(ctx, `WHERE ledger_sequence > $1`, checkpoint, p.batchSize+1)
+	if err != nil {
+		return nil, err
+	}
+
+	selected, overflowLedger, needFullLedger := selectCompleteLedgerBatch(candidates, p.batchSize)
+	if !needFullLedger {
+		return selected, nil
+	}
+
+	// The first unseen ledger alone contains more transactions than the nominal
+	// batch size. Process that whole ledger in one go so we make forward progress
+	// without ever checkpointing a partial ledger.
+	return p.queryCandidateBatch(ctx, `WHERE ledger_sequence = $1`, overflowLedger, 0)
+}
+
+func selectCompleteLedgerBatch(candidates []txMeta, batchSize int) (selected []txMeta, overflowLedger int64, needFullLedger bool) {
+	if len(candidates) <= batchSize {
+		return candidates, 0, false
+	}
+
+	overflowLedger = candidates[batchSize].LedgerSequence
+	cut := batchSize
+	for cut > 0 && candidates[cut-1].LedgerSequence == overflowLedger {
+		cut--
+	}
+	if cut > 0 {
+		return candidates[:cut], overflowLedger, false
+	}
+	return nil, overflowLedger, true
+}
+
+func (p *TxReceiptsProjector) queryCandidateBatch(ctx context.Context, whereClause string, arg any, limit int) ([]txMeta, error) {
+	query := fmt.Sprintf(`
+		SELECT
+			transaction_hash,
+			MIN(ledger_sequence) AS ledger_sequence,
+			COALESCE(MIN(ledger_closed_at), MIN(created_at), now()) AS created_at,
+			MIN(source_account) FILTER (WHERE source_account IS NOT NULL AND source_account <> '') AS source_account,
+			BOOL_OR(COALESCE(tx_successful, false)) AS successful
+		FROM enriched_history_operations
+		%s
+		GROUP BY transaction_hash
+		ORDER BY MIN(ledger_sequence) ASC, transaction_hash ASC
+	`, whereClause)
+	args := []any{arg}
+	if limit > 0 {
+		query += ` LIMIT $2`
+		args = append(args, limit)
+	}
+
+	queryArgs := make([]any, 0, len(args)+1)
+	queryArgs = append(queryArgs, pgx.QueryExecModeSimpleProtocol)
+	queryArgs = append(queryArgs, args...)
+
+	rows, err := p.silverPool.Query(ctx, query, queryArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("query tx-receipt candidates: %w", err)
+	}
+	defer rows.Close()
+
+	var candidates []txMeta
+	for rows.Next() {
+		var m txMeta
+		var src *string
+		if err := rows.Scan(&m.TxHash, &m.LedgerSequence, &m.CreatedAt, &src, &m.Successful); err != nil {
+			return nil, fmt.Errorf("scan tx-receipt candidate: %w", err)
+		}
+		if src != nil {
+			m.SourceAccount = *src
+		}
+		candidates = append(candidates, m)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate tx-receipt candidates: %w", err)
+	}
+	return candidates, nil
+}
+
+func buildReceiptSummary(ops []receiptOperation, toks []receiptTokenEvent) txview.TxSummary {
+	summary := generateProjectorTxSummary(receiptOpsToProjectorOps(ops), receiptEventsToProjectorEvents(toks))
+	return txview.TxSummary{
+		Description:       summary.Description,
+		Type:              summary.Type,
+		InvolvedContracts: summary.InvolvedContracts,
+		Transfer:          convertTransferDetail(summary.Transfer),
+		Mint:              convertTransferDetail(summary.Mint),
+		Burn:              convertTransferDetail(summary.Burn),
+		Swap:              convertSwapDetail(summary.Swap),
+	}
+}
+
+func buildReceiptSemanticPayload(meta txMeta, ops []receiptOperation, toks []receiptTokenEvent, summary txview.TxSummary) txview.SemanticTransactionResponse {
+	closedAt := meta.CreatedAt.UTC().Format(time.RFC3339)
+	return txview.BuildSemanticResponse(txview.TransactionInfo{
+		TxHash:                       meta.TxHash,
+		LedgerSequence:               meta.LedgerSequence,
+		ClosedAt:                     closedAt,
+		Successful:                   meta.Successful,
+		Fee:                          meta.Fee,
+		OperationCount:               len(ops),
+		SourceAccount:                stringPtrIfNotEmpty(meta.SourceAccount),
+		AccountSequence:              meta.AccountSequence,
+		MaxFee:                       meta.MaxFee,
+		SorobanResourcesInstructions: meta.SorobanResourcesInstructions,
+		SorobanResourcesReadBytes:    meta.SorobanResourcesReadBytes,
+		SorobanResourcesWriteBytes:   meta.SorobanResourcesWriteBytes,
+	}, receiptOpsToTxViewOps(ops), receiptEventsToTxViewEvents(toks), summary)
+}
+
+func receiptOpsToProjectorOps(ops []receiptOperation) []projectorDecodedOperation {
+	out := make([]projectorDecodedOperation, 0, len(ops))
+	for _, op := range ops {
+		out = append(out, projectorDecodedOperation{
+			Index:         op.Index,
+			Type:          int32(op.Type),
+			TypeName:      op.TypeName,
+			SourceAccount: derefString(op.SourceAccount),
+			ContractID:    op.ContractID,
+			FunctionName:  op.FunctionName,
+			Destination:   op.Destination,
+			AssetCode:     op.AssetCode,
+			Amount:        op.Amount,
+			IsSorobanOp:   op.IsSoroban,
+		})
+	}
+	return out
+}
+
+func receiptEventsToProjectorEvents(events []receiptTokenEvent) []projectorUnifiedEvent {
+	out := make([]projectorUnifiedEvent, 0, len(events))
+	for _, ev := range events {
+		out = append(out, projectorUnifiedEvent{
+			ContractID: ev.ContractID,
+			EventType:  ev.EventType,
+			From:       ev.From,
+			To:         ev.To,
+			Amount:     ev.Amount,
+			AssetCode:  ev.AssetCode,
+		})
+	}
+	return out
+}
+
+func receiptOpsToTxViewOps(ops []receiptOperation) []txview.Operation {
+	out := make([]txview.Operation, 0, len(ops))
+	for _, op := range ops {
+		out = append(out, txview.Operation{
+			Index:         op.Index,
+			Type:          int32(op.Type),
+			TypeName:      op.TypeName,
+			SourceAccount: derefString(op.SourceAccount),
+			ContractID:    op.ContractID,
+			FunctionName:  op.FunctionName,
+			Destination:   op.Destination,
+			AssetCode:     op.AssetCode,
+			Amount:        op.Amount,
+			IsSorobanOp:   op.IsSoroban,
+		})
+	}
+	return out
+}
+
+func receiptEventsToTxViewEvents(events []receiptTokenEvent) []txview.Event {
+	out := make([]txview.Event, 0, len(events))
+	for _, ev := range events {
+		out = append(out, txview.Event{
+			EventID:        ev.EventID,
+			ContractID:     ev.ContractID,
+			LedgerSequence: ev.LedgerSequence,
+			TxHash:         ev.TxHash,
+			ClosedAt:       ev.ClosedAt,
+			EventType:      ev.EventType,
+			From:           ev.From,
+			To:             ev.To,
+			Amount:         ev.Amount,
+			AssetCode:      ev.AssetCode,
+			AssetIssuer:    ev.AssetIssuer,
+			SourceType:     ev.SourceType,
+			OperationType:  ev.OperationType,
+			EventIndex:     ev.EventIndex,
+		})
+	}
+	return out
+}
+
+func convertTransferDetail(in *TransferDetail) *txview.TransferDetail {
+	if in == nil {
+		return nil
+	}
+	return &txview.TransferDetail{Asset: in.Asset, Amount: in.Amount, From: in.From, To: in.To}
+}
+
+func convertSwapDetail(in *SwapDetail) *txview.SwapDetail {
+	if in == nil {
+		return nil
+	}
+	return &txview.SwapDetail{
+		SoldAsset:    in.SoldAsset,
+		SoldAmount:   in.SoldAmount,
+		BoughtAsset:  in.BoughtAsset,
+		BoughtAmount: in.BoughtAmount,
+		Router:       in.Router,
+		Trader:       in.Trader,
+	}
+}
+
+func stringPtrIfNotEmpty(v string) *string {
+	if v == "" {
+		return nil
+	}
+	return &v
+}
+
+func derefString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+func firstOrNil(s []string) *string {
+	if len(s) == 0 {
+		return nil
+	}
+	return &s[0]
+}
+
+func nullable(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}

--- a/obsrvr-lake/serving-projection-processor/go/tx_receipts_projector_test.go
+++ b/obsrvr-lake/serving-projection-processor/go/tx_receipts_projector_test.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSelectCompleteLedgerBatch_TrimsPartialOverflowLedger(t *testing.T) {
+	now := time.Unix(1710000000, 0).UTC()
+	candidates := []txMeta{
+		{TxHash: "tx-101-a", LedgerSequence: 101, CreatedAt: now},
+		{TxHash: "tx-101-b", LedgerSequence: 101, CreatedAt: now},
+		{TxHash: "tx-102-a", LedgerSequence: 102, CreatedAt: now},
+		{TxHash: "tx-102-b", LedgerSequence: 102, CreatedAt: now},
+		{TxHash: "tx-102-c", LedgerSequence: 102, CreatedAt: now},
+	}
+
+	selected, overflowLedger, needFullLedger := selectCompleteLedgerBatch(candidates, 3)
+	if needFullLedger {
+		t.Fatalf("expected trim behavior, got needFullLedger=true")
+	}
+	if overflowLedger != 102 {
+		t.Fatalf("expected overflow ledger 102, got %d", overflowLedger)
+	}
+	if len(selected) != 2 {
+		t.Fatalf("expected 2 selected candidates, got %d", len(selected))
+	}
+	for i, got := range selected {
+		if got.LedgerSequence != 101 {
+			t.Fatalf("selected[%d] ledger=%d, want 101", i, got.LedgerSequence)
+		}
+	}
+}
+
+func TestSelectCompleteLedgerBatch_RequestsWholeLedgerWhenFirstLedgerExceedsBatch(t *testing.T) {
+	now := time.Unix(1710000000, 0).UTC()
+	candidates := []txMeta{
+		{TxHash: "tx-101-a", LedgerSequence: 101, CreatedAt: now},
+		{TxHash: "tx-101-b", LedgerSequence: 101, CreatedAt: now},
+		{TxHash: "tx-101-c", LedgerSequence: 101, CreatedAt: now},
+		{TxHash: "tx-101-d", LedgerSequence: 101, CreatedAt: now},
+	}
+
+	selected, overflowLedger, needFullLedger := selectCompleteLedgerBatch(candidates, 3)
+	if !needFullLedger {
+		t.Fatalf("expected needFullLedger=true")
+	}
+	if overflowLedger != 101 {
+		t.Fatalf("expected overflow ledger 101, got %d", overflowLedger)
+	}
+	if len(selected) != 0 {
+		t.Fatalf("expected no selected candidates before full-ledger reload, got %d", len(selected))
+	}
+}
+
+func TestSelectCompleteLedgerBatch_ReturnsAllWhenNoOverflow(t *testing.T) {
+	now := time.Unix(1710000000, 0).UTC()
+	candidates := []txMeta{
+		{TxHash: "tx-101-a", LedgerSequence: 101, CreatedAt: now},
+		{TxHash: "tx-101-b", LedgerSequence: 101, CreatedAt: now},
+		{TxHash: "tx-102-a", LedgerSequence: 102, CreatedAt: now},
+	}
+
+	selected, overflowLedger, needFullLedger := selectCompleteLedgerBatch(candidates, 3)
+	if needFullLedger {
+		t.Fatalf("expected needFullLedger=false")
+	}
+	if overflowLedger != 0 {
+		t.Fatalf("expected overflow ledger 0, got %d", overflowLedger)
+	}
+	if len(selected) != len(candidates) {
+		t.Fatalf("expected all candidates to be selected, got %d want %d", len(selected), len(candidates))
+	}
+}
+
+func TestBuildReceiptSemanticPayload_PrefersOperationDerivedSummary(t *testing.T) {
+	asset := "VNM"
+	source := "GD5EJ3SGABU3N7OQ44NSPT4I6YQFW3CD54Z7DYZXOLFNC4MM3JWJDT2Q"
+	ops := []receiptOperation{{
+		Index:         0,
+		Type:          6,
+		TypeName:      "change_trust",
+		SourceAccount: &source,
+		AssetCode:     &asset,
+	}}
+
+	summary := buildReceiptSummary(ops, nil)
+	payload := buildReceiptSemanticPayload(txMeta{
+		TxHash:         "tx",
+		LedgerSequence: 123,
+		CreatedAt:      time.Unix(1710000000, 0).UTC(),
+		SourceAccount:  source,
+		Successful:     false,
+	}, ops, nil, summary)
+	if payload.Classification.TxType != "trustline_change" {
+		t.Fatalf("expected classification tx_type=trustline_change, got %q", payload.Classification.TxType)
+	}
+	if payload.LegacySummary.Type != "change_trust" {
+		t.Fatalf("expected legacy summary type=change_trust, got %q", payload.LegacySummary.Type)
+	}
+	if payload.LegacySummary.Description != "Added trustline for VNM" {
+		t.Fatalf("expected trustline description, got %q", payload.LegacySummary.Description)
+	}
+}
+
+func TestDeriveBalanceDiffs_SignedNetByAccountAndAsset(t *testing.T) {
+	accountFrom := "GBEHX6KXV5RIZWHL7U7NVCMGUUXR43RNMT33WKLPSHS7QLEJZUBHBNKT"
+	accountTo := "GDQF6BZW4WEB3SMUNZ4FJXWXWSPGPES6ETUYRUVIS5LKUDDWYZJ22X4D"
+	assetCode := "DSD"
+	assetIssuer := "GAVRROR6AWJGKOHWLKUGO3OR3UHZ47GBXHHW6PBIVPG55VBMVD3TMLNA"
+	amount := "0.2900000"
+
+	diffs := deriveBalanceDiffs([]receiptEffect{
+		{EffectType: "account_credited", AccountID: &accountTo, AssetCode: &assetCode, AssetIssuer: &assetIssuer, Amount: &amount},
+		{EffectType: "account_debited", AccountID: &accountFrom, AssetCode: &assetCode, AssetIssuer: &assetIssuer, Amount: &amount},
+	})
+	if len(diffs) != 2 {
+		t.Fatalf("expected 2 diffs, got %d", len(diffs))
+	}
+	got := map[string]string{}
+	for _, diff := range diffs {
+		got[diff.Account] = diff.Delta
+		if diff.Asset != "DSD:GAVRROR6AWJGKOHWLKUGO3OR3UHZ47GBXHHW6PBIVPG55VBMVD3TMLNA" {
+			t.Fatalf("unexpected asset key %q", diff.Asset)
+		}
+	}
+	if got[accountFrom] != "-0.2900000" {
+		t.Fatalf("expected sender delta -0.2900000, got %q", got[accountFrom])
+	}
+	if got[accountTo] != "0.2900000" {
+		t.Fatalf("expected receiver delta 0.2900000, got %q", got[accountTo])
+	}
+}
+
+func TestDeriveBalanceDiffs_NetsOpposingEffects(t *testing.T) {
+	account := "GA123"
+	assetCode := "USD"
+	issuer := "GI123"
+	credit := "5.0000000"
+	debit := "2.0000000"
+
+	diffs := deriveBalanceDiffs([]receiptEffect{
+		{EffectType: "account_credited", AccountID: &account, AssetCode: &assetCode, AssetIssuer: &issuer, Amount: &credit},
+		{EffectType: "account_debited", AccountID: &account, AssetCode: &assetCode, AssetIssuer: &issuer, Amount: &debit},
+	})
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d", len(diffs))
+	}
+	if diffs[0].Delta != "3.0000000" {
+		t.Fatalf("expected net delta 3.0000000, got %q", diffs[0].Delta)
+	}
+}

--- a/obsrvr-lake/serving-projection-processor/go/txview/build.go
+++ b/obsrvr-lake/serving-projection-processor/go/txview/build.go
@@ -1,0 +1,269 @@
+package txview
+
+import "sort"
+
+func BuildSemanticResponse(info TransactionInfo, ops []Operation, events []Event, summary TxSummary) SemanticTransactionResponse {
+	actors := BuildBasicActors(info, ops, events)
+	return SemanticTransactionResponse{
+		Transaction:    info,
+		Classification: ClassifyTransaction(summary, ops, actors),
+		Actors:         actors,
+		Assets:         DeriveAssetContext(summary, ops, events),
+		Operations:     ops,
+		Events:         events,
+		LegacySummary:  summary,
+	}
+}
+
+func BuildBasicActors(info TransactionInfo, ops []Operation, events []Event) []SemanticActor {
+	type actorState struct {
+		actor      SemanticActor
+		roles      map[string]struct{}
+		contractID *string
+	}
+	actors := map[string]*actorState{}
+	add := func(actorID, actorType, role string, contractID *string) {
+		if actorID == "" {
+			return
+		}
+		st, ok := actors[actorID]
+		if !ok {
+			st = &actorState{actor: SemanticActor{ActorID: actorID, ActorType: actorType}, roles: map[string]struct{}{}}
+			actors[actorID] = st
+		}
+		if actorType != "" {
+			st.actor.ActorType = actorType
+		}
+		if contractID != nil {
+			st.actor.ContractID = contractID
+		}
+		if role != "" {
+			st.roles[role] = struct{}{}
+		}
+	}
+
+	submitter := ""
+	if info.SourceAccount != nil {
+		submitter = *info.SourceAccount
+	}
+	if submitter == "" && len(ops) > 0 {
+		submitter = ops[0].SourceAccount
+	}
+	if submitter != "" {
+		add(submitter, actorTypeForID(submitter), "submitter", nil)
+		add(submitter, actorTypeForID(submitter), "fee_payer", nil)
+	}
+
+	for _, op := range ops {
+		if op.SourceAccount != "" {
+			add(op.SourceAccount, actorTypeForID(op.SourceAccount), "counterparty", nil)
+			if op.IsSorobanOp {
+				add(op.SourceAccount, actorTypeForID(op.SourceAccount), "invoker", nil)
+			} else {
+				add(op.SourceAccount, actorTypeForID(op.SourceAccount), "effective_actor", nil)
+			}
+		}
+		if op.Destination != nil {
+			add(*op.Destination, actorTypeForID(*op.Destination), "receiver", nil)
+			add(*op.Destination, actorTypeForID(*op.Destination), "beneficiary", nil)
+		}
+		if op.ContractID != nil {
+			add(*op.ContractID, actorTypeForID(*op.ContractID), "protocol", op.ContractID)
+		}
+	}
+
+	for _, event := range events {
+		if event.From != nil {
+			add(*event.From, actorTypeForID(*event.From), "sender", nil)
+			add(*event.From, actorTypeForID(*event.From), "asset_owner", nil)
+			add(*event.From, actorTypeForID(*event.From), "effective_actor", nil)
+		}
+		if event.To != nil {
+			add(*event.To, actorTypeForID(*event.To), "receiver", nil)
+			add(*event.To, actorTypeForID(*event.To), "beneficiary", nil)
+		}
+		if event.ContractID != nil {
+			add(*event.ContractID, actorTypeForID(*event.ContractID), "protocol", event.ContractID)
+		}
+	}
+
+	if submitter != "" {
+		if st, ok := actors[submitter]; ok {
+			if _, has := st.roles["effective_actor"]; !has {
+				st.roles["effective_actor"] = struct{}{}
+			}
+		}
+	}
+
+	out := make([]SemanticActor, 0, len(actors))
+	for _, st := range actors {
+		roles := make([]string, 0, len(st.roles))
+		for role := range st.roles {
+			roles = append(roles, role)
+		}
+		sort.Strings(roles)
+		st.actor.Roles = roles
+		out = append(out, st.actor)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ActorID < out[j].ActorID })
+	return out
+}
+
+func ClassifyTransaction(summary TxSummary, ops []Operation, actors []SemanticActor) SemanticTransactionClassification {
+	opTypes := make([]string, 0, len(ops))
+	seen := map[string]struct{}{}
+	for _, op := range ops {
+		if op.TypeName == "" {
+			continue
+		}
+		if _, ok := seen[op.TypeName]; ok {
+			continue
+		}
+		seen[op.TypeName] = struct{}{}
+		opTypes = append(opTypes, op.TypeName)
+	}
+	sort.Strings(opTypes)
+
+	txType := summary.Type
+	subtype := ""
+	switch summary.Type {
+	case "change_trust":
+		txType = "trustline_change"
+	case "contract_call":
+		if len(ops) == 1 && ops[0].FunctionName != nil {
+			subtype = *ops[0].FunctionName
+		}
+	}
+	if txType == "" || txType == "unknown" {
+		if len(opTypes) > 0 {
+			txType = opTypes[0]
+		} else {
+			txType = "unknown"
+		}
+	}
+
+	effectiveActorType := ""
+	walletInvolved := false
+	for _, actor := range actors {
+		if actor.ActorType == "smart_wallet" {
+			walletInvolved = true
+		}
+		for _, role := range actor.Roles {
+			if role == "effective_actor" && effectiveActorType == "" {
+				effectiveActorType = actor.ActorType
+			}
+		}
+	}
+	if effectiveActorType == "" && len(actors) > 0 {
+		effectiveActorType = actors[0].ActorType
+	}
+
+	confidence := "high"
+	if txType == "unknown" {
+		confidence = "low"
+	}
+	return SemanticTransactionClassification{
+		TxType:             txType,
+		Subtype:            subtype,
+		Confidence:         confidence,
+		OperationTypes:     opTypes,
+		WalletInvolved:     walletInvolved,
+		EffectiveActorType: effectiveActorType,
+	}
+}
+
+func DeriveAssetContext(summary TxSummary, ops []Operation, events []Event) SemanticAssetContext {
+	ctx := SemanticAssetContext{}
+	movements := make([]SemanticAssetMovement, 0, len(events))
+	for _, e := range events {
+		movement := SemanticAssetMovement{
+			Amount:   deref(e.Amount),
+			Asset:    eventAsset(e),
+			From:     e.From,
+			To:       e.To,
+			Contract: e.ContractID,
+			Kind:     e.EventType,
+		}
+		movements = append(movements, movement)
+	}
+	if len(movements) == 0 {
+		switch {
+		case summary.Transfer != nil:
+			movements = append(movements, SemanticAssetMovement{Amount: summary.Transfer.Amount, Asset: summary.Transfer.Asset, Kind: "transfer", From: stringPtrOrNil(summary.Transfer.From), To: stringPtrOrNil(summary.Transfer.To)})
+		case summary.Mint != nil:
+			movements = append(movements, SemanticAssetMovement{Amount: summary.Mint.Amount, Asset: summary.Mint.Asset, Kind: "mint", To: stringPtrOrNil(summary.Mint.To)})
+		case summary.Burn != nil:
+			movements = append(movements, SemanticAssetMovement{Amount: summary.Burn.Amount, Asset: summary.Burn.Asset, Kind: "burn", From: stringPtrOrNil(summary.Burn.From)})
+		}
+	}
+	ctx.Movements = movements
+	for i := range movements {
+		m := movements[i]
+		switch m.Kind {
+		case "burn":
+			if ctx.Sent == nil {
+				mv := m
+				ctx.Sent = &mv
+			}
+		case "mint":
+			if ctx.Received == nil {
+				mv := m
+				ctx.Received = &mv
+			}
+		default:
+			if ctx.Sent == nil {
+				mv := m
+				ctx.Sent = &mv
+			}
+			if ctx.Received == nil {
+				mv := m
+				ctx.Received = &mv
+			}
+		}
+	}
+	if summary.Swap != nil {
+		ctx.Path = []string{summary.Swap.SoldAsset, summary.Swap.BoughtAsset}
+	}
+	return ctx
+}
+
+func actorTypeForID(actorID string) string {
+	if actorID == "" {
+		return "unknown_actor"
+	}
+	switch actorID[0] {
+	case 'G':
+		return "classic_account"
+	case 'C':
+		return "contract"
+	default:
+		return "unknown_actor"
+	}
+}
+
+func eventAsset(e Event) string {
+	if e.AssetCode != nil && *e.AssetCode != "" {
+		if e.AssetIssuer != nil && *e.AssetIssuer != "" {
+			return *e.AssetCode + ":" + *e.AssetIssuer
+		}
+		return *e.AssetCode
+	}
+	if e.ContractID != nil && *e.ContractID != "" {
+		return *e.ContractID
+	}
+	return "asset"
+}
+
+func deref(v *string) string {
+	if v == nil {
+		return ""
+	}
+	return *v
+}
+
+func stringPtrOrNil(v string) *string {
+	if v == "" {
+		return nil
+	}
+	return &v
+}

--- a/obsrvr-lake/serving-projection-processor/go/txview/types.go
+++ b/obsrvr-lake/serving-projection-processor/go/txview/types.go
@@ -1,0 +1,129 @@
+package txview
+
+type SwapDetail struct {
+	SoldAsset    string `json:"sold_asset"`
+	SoldAmount   string `json:"sold_amount"`
+	BoughtAsset  string `json:"bought_asset"`
+	BoughtAmount string `json:"bought_amount"`
+	Router       string `json:"router,omitempty"`
+	Trader       string `json:"trader"`
+}
+
+type TransferDetail struct {
+	Asset  string `json:"asset"`
+	Amount string `json:"amount"`
+	From   string `json:"from,omitempty"`
+	To     string `json:"to,omitempty"`
+}
+
+type TxSummary struct {
+	Description       string          `json:"description"`
+	Type              string          `json:"type"`
+	InvolvedContracts []string        `json:"involved_contracts,omitempty"`
+	Swap              *SwapDetail     `json:"swap,omitempty"`
+	Transfer          *TransferDetail `json:"transfer,omitempty"`
+	Mint              *TransferDetail `json:"mint,omitempty"`
+	Burn              *TransferDetail `json:"burn,omitempty"`
+}
+
+type TransactionInfo struct {
+	TxHash                       string  `json:"tx_hash"`
+	LedgerSequence               int64   `json:"ledger_sequence"`
+	ClosedAt                     string  `json:"closed_at"`
+	Successful                   bool    `json:"successful"`
+	Fee                          int64   `json:"fee"`
+	OperationCount               int     `json:"operation_count"`
+	SourceAccount                *string `json:"source_account,omitempty"`
+	AccountSequence              *int64  `json:"account_sequence,omitempty"`
+	MaxFee                       *int64  `json:"max_fee,omitempty"`
+	SorobanResourcesInstructions *int64  `json:"soroban_resources_instructions,omitempty"`
+	SorobanResourcesReadBytes    *int64  `json:"soroban_resources_read_bytes,omitempty"`
+	SorobanResourcesWriteBytes   *int64  `json:"soroban_resources_write_bytes,omitempty"`
+}
+
+type Operation struct {
+	Index         int     `json:"index"`
+	Type          int32   `json:"type"`
+	TypeName      string  `json:"type_name"`
+	SourceAccount string  `json:"source_account"`
+	ContractID    *string `json:"contract_id,omitempty"`
+	FunctionName  *string `json:"function_name,omitempty"`
+	ArgumentsJSON *string `json:"arguments_json,omitempty"`
+	Destination   *string `json:"destination,omitempty"`
+	AssetCode     *string `json:"asset_code,omitempty"`
+	Amount        *string `json:"amount,omitempty"`
+	IsSorobanOp   bool    `json:"is_soroban_op"`
+}
+
+type Event struct {
+	EventID        string  `json:"event_id"`
+	ContractID     *string `json:"contract_id,omitempty"`
+	LedgerSequence int64   `json:"ledger_sequence"`
+	TxHash         string  `json:"tx_hash"`
+	ClosedAt       string  `json:"closed_at"`
+	EventType      string  `json:"event_type"`
+	From           *string `json:"from,omitempty"`
+	To             *string `json:"to,omitempty"`
+	Amount         *string `json:"amount,omitempty"`
+	AssetCode      *string `json:"asset_code,omitempty"`
+	AssetIssuer    *string `json:"asset_issuer,omitempty"`
+	TokenName      *string `json:"token_name,omitempty"`
+	TokenSymbol    *string `json:"token_symbol,omitempty"`
+	TokenDecimals  *int    `json:"token_decimals,omitempty"`
+	TokenType      *string `json:"token_type,omitempty"`
+	SourceType     string  `json:"source_type"`
+	OperationType  *int32  `json:"operation_type,omitempty"`
+	EventIndex     int     `json:"event_index"`
+}
+
+type SemanticTransactionClassification struct {
+	TxType             string   `json:"tx_type"`
+	Subtype            string   `json:"subtype,omitempty"`
+	Confidence         string   `json:"confidence"`
+	OperationTypes     []string `json:"operation_types,omitempty"`
+	WalletInvolved     bool     `json:"wallet_involved"`
+	EffectiveActorType string   `json:"effective_actor_type,omitempty"`
+}
+
+type SemanticActor struct {
+	ActorID    string                 `json:"actor_id"`
+	ActorType  string                 `json:"actor_type"`
+	Label      *string                `json:"label,omitempty"`
+	Roles      []string               `json:"roles"`
+	Wallet     *SemanticWalletContext `json:"wallet,omitempty"`
+	ContractID *string                `json:"contract_id,omitempty"`
+}
+
+type SemanticWalletContext struct {
+	WalletType     string  `json:"wallet_type,omitempty"`
+	Implementation string  `json:"implementation,omitempty"`
+	Confidence     float64 `json:"confidence,omitempty"`
+	HasCheckAuth   bool    `json:"has_check_auth,omitempty"`
+	SignerCount    int     `json:"signer_count,omitempty"`
+}
+
+type SemanticAssetContext struct {
+	Sent      *SemanticAssetMovement  `json:"sent,omitempty"`
+	Received  *SemanticAssetMovement  `json:"received,omitempty"`
+	Movements []SemanticAssetMovement `json:"movements,omitempty"`
+	Path      []string                `json:"path,omitempty"`
+}
+
+type SemanticAssetMovement struct {
+	Amount   string  `json:"amount"`
+	Asset    string  `json:"asset"`
+	From     *string `json:"from,omitempty"`
+	To       *string `json:"to,omitempty"`
+	Contract *string `json:"contract,omitempty"`
+	Kind     string  `json:"kind,omitempty"`
+}
+
+type SemanticTransactionResponse struct {
+	Transaction    TransactionInfo                   `json:"transaction"`
+	Classification SemanticTransactionClassification `json:"classification"`
+	Actors         []SemanticActor                   `json:"actors"`
+	Assets         SemanticAssetContext              `json:"assets"`
+	Operations     []Operation                       `json:"operations"`
+	Events         []Event                           `json:"events"`
+	LegacySummary  TxSummary                         `json:"legacy_summary"`
+}

--- a/obsrvr-lake/serving-projection-processor/migrations/001_create_sv_defi_protocol_registry.sql
+++ b/obsrvr-lake/serving-projection-processor/migrations/001_create_sv_defi_protocol_registry.sql
@@ -1,0 +1,61 @@
+-- DeFi protocol registry and protocol contract role mapping
+-- Target DB: silver_hot (serving schema)
+
+CREATE SCHEMA IF NOT EXISTS serving;
+
+CREATE TABLE IF NOT EXISTS serving.sv_defi_protocols (
+    protocol_id                    TEXT PRIMARY KEY,
+    network                        TEXT NOT NULL,                 -- testnet, mainnet
+    display_name                   TEXT NOT NULL,
+    slug                           TEXT NOT NULL,
+    version                        TEXT,
+    category                       TEXT NOT NULL,                 -- lending, amm, stable, yield, derivatives
+    status                         TEXT NOT NULL DEFAULT 'active',-- active, degraded, paused, retired
+    adapter_name                   TEXT NOT NULL,                 -- blend_v1, aquarius_v1, etc.
+    pricing_model                  TEXT NOT NULL,                 -- oracle_spot, dex_twap, reserve_share, custom
+    health_model                   TEXT,                          -- null if protocol has no health factor
+    supports_history               BOOLEAN NOT NULL DEFAULT TRUE,
+    supports_rewards               BOOLEAN NOT NULL DEFAULT FALSE,
+    supports_health_factor         BOOLEAN NOT NULL DEFAULT FALSE,
+    website_url                    TEXT,
+    docs_url                       TEXT,
+    icon_url                       TEXT,
+    config_json                    JSONB NOT NULL DEFAULT '{}'::jsonb,
+    source                         TEXT NOT NULL DEFAULT 'manual',-- manual, discovered, imported
+    verified                       BOOLEAN NOT NULL DEFAULT FALSE,
+    last_updated_ledger            BIGINT,
+    last_updated_at                TIMESTAMPTZ,
+    created_at                     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at                     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT sv_defi_protocols_status_chk CHECK (status IN ('active', 'degraded', 'paused', 'retired'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_sv_defi_protocols_network_slug
+    ON serving.sv_defi_protocols (network, slug);
+CREATE INDEX IF NOT EXISTS idx_sv_defi_protocols_category
+    ON serving.sv_defi_protocols (category);
+CREATE INDEX IF NOT EXISTS idx_sv_defi_protocols_status
+    ON serving.sv_defi_protocols (status);
+
+CREATE TABLE IF NOT EXISTS serving.sv_defi_protocol_contracts (
+    protocol_id                    TEXT NOT NULL REFERENCES serving.sv_defi_protocols(protocol_id) ON DELETE CASCADE,
+    contract_id                    TEXT NOT NULL,
+    role                           TEXT NOT NULL,                 -- router, pool, market, oracle, backstop, factory, vault, emissions
+    market_id                      TEXT,
+    is_active                      BOOLEAN NOT NULL DEFAULT TRUE,
+    verified                       BOOLEAN NOT NULL DEFAULT FALSE,
+    source                         TEXT NOT NULL DEFAULT 'manual',
+    metadata_json                  JSONB NOT NULL DEFAULT '{}'::jsonb,
+    first_seen_ledger              BIGINT,
+    last_seen_ledger               BIGINT,
+    created_at                     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at                     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (protocol_id, contract_id, role)
+);
+
+CREATE INDEX IF NOT EXISTS idx_sv_defi_protocol_contracts_contract
+    ON serving.sv_defi_protocol_contracts (contract_id);
+CREATE INDEX IF NOT EXISTS idx_sv_defi_protocol_contracts_role
+    ON serving.sv_defi_protocol_contracts (protocol_id, role, is_active);
+CREATE INDEX IF NOT EXISTS idx_sv_defi_protocol_contracts_market
+    ON serving.sv_defi_protocol_contracts (market_id) WHERE market_id IS NOT NULL;

--- a/obsrvr-lake/serving-projection-processor/migrations/002_create_sv_defi_markets_current.sql
+++ b/obsrvr-lake/serving-projection-processor/migrations/002_create_sv_defi_markets_current.sql
@@ -1,0 +1,57 @@
+-- Current DeFi market registry / serving table
+-- Target DB: silver_hot (serving schema)
+
+CREATE SCHEMA IF NOT EXISTS serving;
+
+CREATE TABLE IF NOT EXISTS serving.sv_defi_markets_current (
+    market_id                      TEXT PRIMARY KEY,
+    protocol_id                    TEXT NOT NULL REFERENCES serving.sv_defi_protocols(protocol_id) ON DELETE CASCADE,
+    market_type                    TEXT NOT NULL,                -- lending_pool, lp_pool, vault, backstop, stable_pool
+    market_address                 TEXT,
+    pool_address                   TEXT,
+    router_address                 TEXT,
+    oracle_contract_id             TEXT,
+
+    input_asset_1_type             TEXT,
+    input_asset_1_code             TEXT,
+    input_asset_1_issuer           TEXT,
+    input_asset_1_contract_id      TEXT,
+    input_asset_1_symbol           TEXT,
+    input_asset_1_decimals         INTEGER,
+
+    input_asset_2_type             TEXT,
+    input_asset_2_code             TEXT,
+    input_asset_2_issuer           TEXT,
+    input_asset_2_contract_id      TEXT,
+    input_asset_2_symbol           TEXT,
+    input_asset_2_decimals         INTEGER,
+
+    share_asset_contract_id        TEXT,
+    debt_asset_contract_id         TEXT,
+    collateral_asset_contract_id   TEXT,
+
+    oracle_source                  TEXT,
+    is_active                      BOOLEAN NOT NULL DEFAULT TRUE,
+    metadata_json                  JSONB NOT NULL DEFAULT '{}'::jsonb,
+
+    tvl_value_usd                  NUMERIC(38,10),
+    total_deposit_value_usd        NUMERIC(38,10),
+    total_borrowed_value_usd       NUMERIC(38,10),
+    total_rewards_value_usd        NUMERIC(38,10),
+    apr_deposit                    NUMERIC(20,10),
+    apr_borrow                     NUMERIC(20,10),
+    apr_rewards                    NUMERIC(20,10),
+
+    as_of_ledger                   BIGINT NOT NULL,
+    as_of_time                     TIMESTAMPTZ NOT NULL,
+    updated_at                     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_sv_defi_markets_protocol
+    ON serving.sv_defi_markets_current (protocol_id, market_type, is_active);
+CREATE INDEX IF NOT EXISTS idx_sv_defi_markets_market_address
+    ON serving.sv_defi_markets_current (market_address) WHERE market_address IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_sv_defi_markets_pool_address
+    ON serving.sv_defi_markets_current (pool_address) WHERE pool_address IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_sv_defi_markets_tvl
+    ON serving.sv_defi_markets_current (tvl_value_usd DESC);

--- a/obsrvr-lake/serving-projection-processor/migrations/003_create_sv_defi_positions_current.sql
+++ b/obsrvr-lake/serving-projection-processor/migrations/003_create_sv_defi_positions_current.sql
@@ -1,0 +1,97 @@
+-- Current DeFi positions and component breakdowns
+-- Target DB: silver_hot (serving schema)
+
+CREATE SCHEMA IF NOT EXISTS serving;
+
+CREATE TABLE IF NOT EXISTS serving.sv_defi_positions_current (
+    position_id                    TEXT PRIMARY KEY,
+    protocol_id                    TEXT NOT NULL REFERENCES serving.sv_defi_protocols(protocol_id) ON DELETE CASCADE,
+    protocol_version               TEXT,
+    position_type                  TEXT NOT NULL,                -- lending_supply, lending_borrow, lp_position, backstop_position, vault_deposit
+    status                         TEXT NOT NULL,                -- open, closed, liquidated, archived
+    owner_address                  TEXT NOT NULL,                -- user identity supplied by client (G... or C...)
+    account_address                TEXT,                         -- actual holding address if different
+    related_address                TEXT,
+    market_id                      TEXT REFERENCES serving.sv_defi_markets_current(market_id) ON DELETE SET NULL,
+    market_address                 TEXT,
+    position_key_hash              TEXT,
+
+    underlying_asset_type          TEXT,
+    underlying_asset_code          TEXT,
+    underlying_asset_issuer        TEXT,
+    underlying_asset_contract_id   TEXT,
+    underlying_symbol              TEXT,
+    underlying_decimals            INTEGER,
+
+    quote_currency                 TEXT NOT NULL DEFAULT 'USD',
+    deposit_amount                 NUMERIC(38,18),
+    borrow_amount                  NUMERIC(38,18),
+    share_amount                   NUMERIC(38,18),
+    claimable_reward_amount        NUMERIC(38,18),
+
+    deposit_value                  NUMERIC(38,10),
+    borrowed_value                 NUMERIC(38,10),
+    current_value                  NUMERIC(38,10),
+    net_value                      NUMERIC(38,10),
+    current_return_value           NUMERIC(38,10),
+    current_return_percent         NUMERIC(20,10),
+    claimable_rewards_value        NUMERIC(38,10),
+
+    health_factor                  NUMERIC(20,10),
+    ltv                            NUMERIC(20,10),
+    collateral_ratio               NUMERIC(20,10),
+    liquidation_threshold          NUMERIC(20,10),
+    risk_status                    TEXT,
+
+    opened_at                      TIMESTAMPTZ,
+    opened_ledger                  BIGINT,
+    closed_at                      TIMESTAMPTZ,
+    closed_ledger                  BIGINT,
+
+    protocol_state_json            JSONB NOT NULL DEFAULT '{}'::jsonb,
+    valuation_json                 JSONB NOT NULL DEFAULT '{}'::jsonb,
+    source_json                    JSONB NOT NULL DEFAULT '{}'::jsonb,
+
+    as_of_ledger                   BIGINT NOT NULL,
+    as_of_time                     TIMESTAMPTZ NOT NULL,
+    last_updated_ledger            BIGINT NOT NULL,
+    last_updated_at                TIMESTAMPTZ NOT NULL,
+    updated_at                     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_sv_defi_positions_owner
+    ON serving.sv_defi_positions_current (owner_address, status, as_of_time DESC);
+CREATE INDEX IF NOT EXISTS idx_sv_defi_positions_owner_protocol
+    ON serving.sv_defi_positions_current (owner_address, protocol_id, status);
+CREATE INDEX IF NOT EXISTS idx_sv_defi_positions_market
+    ON serving.sv_defi_positions_current (market_id) WHERE market_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_sv_defi_positions_risk
+    ON serving.sv_defi_positions_current (risk_status, health_factor);
+CREATE INDEX IF NOT EXISTS idx_sv_defi_positions_current_value
+    ON serving.sv_defi_positions_current (current_value DESC);
+
+CREATE TABLE IF NOT EXISTS serving.sv_defi_position_components_current (
+    component_id                   TEXT PRIMARY KEY,
+    position_id                    TEXT NOT NULL REFERENCES serving.sv_defi_positions_current(position_id) ON DELETE CASCADE,
+    protocol_id                    TEXT NOT NULL REFERENCES serving.sv_defi_protocols(protocol_id) ON DELETE CASCADE,
+    component_type                 TEXT NOT NULL,                -- collateral, debt, supplied_asset, lp_leg, reward, fee_claim, backstop_share
+    asset_type                     TEXT,
+    asset_code                     TEXT,
+    asset_issuer                   TEXT,
+    asset_contract_id              TEXT,
+    symbol                         TEXT,
+    decimals                       INTEGER,
+    amount                         NUMERIC(38,18),
+    value                          NUMERIC(38,10),
+    price                          NUMERIC(38,18),
+    price_source                   TEXT,
+    metadata_json                  JSONB NOT NULL DEFAULT '{}'::jsonb,
+    as_of_ledger                   BIGINT NOT NULL,
+    as_of_time                     TIMESTAMPTZ NOT NULL,
+    updated_at                     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_sv_defi_position_components_position
+    ON serving.sv_defi_position_components_current (position_id, component_type);
+CREATE INDEX IF NOT EXISTS idx_sv_defi_position_components_protocol
+    ON serving.sv_defi_position_components_current (protocol_id, component_type);

--- a/obsrvr-lake/serving-projection-processor/migrations/004_create_sv_defi_totals_and_history.sql
+++ b/obsrvr-lake/serving-projection-processor/migrations/004_create_sv_defi_totals_and_history.sql
@@ -1,0 +1,73 @@
+-- User-level aggregates and history snapshots for DeFi positions
+-- Target DB: silver_hot (serving schema)
+
+CREATE SCHEMA IF NOT EXISTS serving;
+
+CREATE TABLE IF NOT EXISTS serving.sv_defi_user_totals_current (
+    owner_address                  TEXT NOT NULL,
+    quote_currency                 TEXT NOT NULL DEFAULT 'USD',
+    total_value                    NUMERIC(38,10) NOT NULL DEFAULT 0,
+    total_deposit_value            NUMERIC(38,10) NOT NULL DEFAULT 0,
+    total_borrowed_value           NUMERIC(38,10) NOT NULL DEFAULT 0,
+    net_value                      NUMERIC(38,10) NOT NULL DEFAULT 0,
+    total_claimable_rewards_value  NUMERIC(38,10) NOT NULL DEFAULT 0,
+    open_position_count            INTEGER NOT NULL DEFAULT 0,
+    protocol_count                 INTEGER NOT NULL DEFAULT 0,
+    lowest_health_factor           NUMERIC(20,10),
+    positions_at_risk              INTEGER NOT NULL DEFAULT 0,
+    by_protocol_json               JSONB NOT NULL DEFAULT '[]'::jsonb,
+    source_json                    JSONB NOT NULL DEFAULT '{}'::jsonb,
+    as_of_ledger                   BIGINT NOT NULL,
+    as_of_time                     TIMESTAMPTZ NOT NULL,
+    updated_at                     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (owner_address, quote_currency)
+);
+
+CREATE INDEX IF NOT EXISTS idx_sv_defi_user_totals_current_value
+    ON serving.sv_defi_user_totals_current (total_value DESC);
+CREATE INDEX IF NOT EXISTS idx_sv_defi_user_totals_health
+    ON serving.sv_defi_user_totals_current (lowest_health_factor);
+
+CREATE TABLE IF NOT EXISTS serving.sv_defi_user_totals_history (
+    owner_address                  TEXT NOT NULL,
+    bucket_start                   TIMESTAMPTZ NOT NULL,
+    interval                       TEXT NOT NULL,                -- 1h, 1d
+    quote_currency                 TEXT NOT NULL DEFAULT 'USD',
+    total_value                    NUMERIC(38,10) NOT NULL DEFAULT 0,
+    total_deposit_value            NUMERIC(38,10) NOT NULL DEFAULT 0,
+    total_borrowed_value           NUMERIC(38,10) NOT NULL DEFAULT 0,
+    net_value                      NUMERIC(38,10) NOT NULL DEFAULT 0,
+    total_claimable_rewards_value  NUMERIC(38,10) NOT NULL DEFAULT 0,
+    open_position_count            INTEGER NOT NULL DEFAULT 0,
+    as_of_ledger                   BIGINT,
+    as_of_time                     TIMESTAMPTZ,
+    PRIMARY KEY (owner_address, interval, quote_currency, bucket_start)
+);
+
+CREATE INDEX IF NOT EXISTS idx_sv_defi_user_totals_history_lookup
+    ON serving.sv_defi_user_totals_history (owner_address, interval, bucket_start DESC);
+
+CREATE TABLE IF NOT EXISTS serving.sv_defi_position_history (
+    position_id                    TEXT NOT NULL,
+    bucket_start                   TIMESTAMPTZ NOT NULL,
+    interval                       TEXT NOT NULL,
+    quote_currency                 TEXT NOT NULL DEFAULT 'USD',
+    protocol_id                    TEXT NOT NULL,
+    owner_address                  TEXT NOT NULL,
+    status                         TEXT,
+    deposit_value                  NUMERIC(38,10),
+    borrowed_value                 NUMERIC(38,10),
+    current_value                  NUMERIC(38,10),
+    net_value                      NUMERIC(38,10),
+    current_return_value           NUMERIC(38,10),
+    health_factor                  NUMERIC(20,10),
+    risk_status                    TEXT,
+    as_of_ledger                   BIGINT,
+    as_of_time                     TIMESTAMPTZ,
+    PRIMARY KEY (position_id, interval, quote_currency, bucket_start)
+);
+
+CREATE INDEX IF NOT EXISTS idx_sv_defi_position_history_owner
+    ON serving.sv_defi_position_history (owner_address, interval, bucket_start DESC);
+CREATE INDEX IF NOT EXISTS idx_sv_defi_position_history_protocol
+    ON serving.sv_defi_position_history (protocol_id, interval, bucket_start DESC);

--- a/obsrvr-lake/serving-projection-processor/migrations/005_create_sv_defi_prices_and_status.sql
+++ b/obsrvr-lake/serving-projection-processor/migrations/005_create_sv_defi_prices_and_status.sql
@@ -1,0 +1,44 @@
+-- Price inputs and protocol operational status for DeFi serving/API
+-- Target DB: silver_hot (serving schema)
+
+CREATE SCHEMA IF NOT EXISTS serving;
+
+CREATE TABLE IF NOT EXISTS serving.sv_defi_prices_current (
+    asset_key                      TEXT NOT NULL,
+    quote_currency                 TEXT NOT NULL DEFAULT 'USD',
+    asset_type                     TEXT,
+    asset_code                     TEXT,
+    asset_issuer                   TEXT,
+    asset_contract_id              TEXT,
+    symbol                         TEXT,
+    price                          NUMERIC(38,18) NOT NULL,
+    price_source                   TEXT NOT NULL,                -- oracle, dex_twap, fixed, derived, manual
+    confidence                     NUMERIC(20,10),
+    source_timestamp               TIMESTAMPTZ,
+    source_ledger                  BIGINT,
+    stale_after_seconds            INTEGER,
+    status                         TEXT NOT NULL DEFAULT 'ok',   -- ok, stale, missing, degraded
+    metadata_json                  JSONB NOT NULL DEFAULT '{}'::jsonb,
+    updated_at                     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (asset_key, quote_currency)
+);
+
+CREATE INDEX IF NOT EXISTS idx_sv_defi_prices_status
+    ON serving.sv_defi_prices_current (status, updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_sv_defi_prices_contract
+    ON serving.sv_defi_prices_current (asset_contract_id) WHERE asset_contract_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS serving.sv_defi_protocol_status (
+    protocol_id                    TEXT PRIMARY KEY REFERENCES serving.sv_defi_protocols(protocol_id) ON DELETE CASCADE,
+    status                         TEXT NOT NULL,                -- ok, degraded, halted, backfill
+    reason                         TEXT,
+    last_successful_ledger         BIGINT,
+    last_successful_time           TIMESTAMPTZ,
+    freshness_seconds              INTEGER,
+    source_divergence              BOOLEAN NOT NULL DEFAULT FALSE,
+    source_json                    JSONB NOT NULL DEFAULT '{}'::jsonb,
+    updated_at                     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_sv_defi_protocol_status_status
+    ON serving.sv_defi_protocol_status (status, updated_at DESC);

--- a/obsrvr-lake/silver-cold-flusher/go/config.go
+++ b/obsrvr-lake/silver-cold-flusher/go/config.go
@@ -141,5 +141,18 @@ func GetTablesToFlush() []string {
 		// testnet despite the rest of silver being pruned to a ~50-min window.
 		"effects",
 		"evicted_keys",
+
+		// Append-only DEX/ledger events (added April 2026 — same leak class
+		// as effects/evicted_keys, just quieter on testnet so it went unnoticed
+		// longer).
+		"trades",
+		"restored_keys",
+
+		// Additional current-state tables (were only in hot PG; now flushed
+		// to cold like accounts_current / trustlines_current / etc. so cold
+		// queries can reconstruct historical state).
+		"native_balances_current",
+		"ttl_current",
+		"address_balances_current",
 	}
 }

--- a/obsrvr-lake/silver-cold-flusher/go/flusher.go
+++ b/obsrvr-lake/silver-cold-flusher/go/flusher.go
@@ -253,12 +253,15 @@ func (f *Flusher) flushAllTables(watermark, lastFlushed int64) (int64, []string,
 		"semantic_flows_value":                true,
 		"effects":                             true,
 		"evicted_keys":                        true,
+		"trades":                              true,
+		"restored_keys":                       true,
 	}
 
 	// Tables with non-standard watermark column
 	customWatermarkCol := map[string]string{
-		"contract_metadata": "created_ledger",
-		"token_registry":    "last_updated_ledger",
+		"contract_metadata":        "created_ledger",
+		"token_registry":           "last_updated_ledger",
+		"address_balances_current": "last_updated_ledger",
 	}
 
 	for _, tableName := range tables {
@@ -314,12 +317,15 @@ func (f *Flusher) deleteFlushedData(watermark int64, tables []string) (int64, er
 		"semantic_flows_value":                true,
 		"effects":                             true,
 		"evicted_keys":                        true,
+		"trades":                              true,
+		"restored_keys":                       true,
 	}
 
 	// Tables with non-standard watermark column
 	customWatermarkCol := map[string]string{
-		"contract_metadata": "created_ledger",
-		"token_registry":    "last_updated_ledger",
+		"contract_metadata":        "created_ledger",
+		"token_registry":           "last_updated_ledger",
+		"address_balances_current": "last_updated_ledger",
 	}
 
 	for _, tableName := range tables {

--- a/obsrvr-lake/silver-cold-flusher/go/silver_maintenance.go
+++ b/obsrvr-lake/silver-cold-flusher/go/silver_maintenance.go
@@ -53,6 +53,16 @@ var SilverTables = []string{
 	// absent from the flush list, causing silver_hot to grow unbounded)
 	"effects",
 	"evicted_keys",
+
+	// Additional event tables (added April 2026 — same leak class as effects;
+	// testnet DEX activity is quiet so these were small when caught)
+	"trades",
+	"restored_keys",
+
+	// Additional current-state tables
+	"native_balances_current",
+	"ttl_current",
+	"address_balances_current",
 }
 
 // HighVolumeSilverTables are tables that accumulate files fastest and need

--- a/obsrvr-lake/silver-cold-flusher/go/silver_schema.go
+++ b/obsrvr-lake/silver-cold-flusher/go/silver_schema.go
@@ -106,6 +106,17 @@ func (c *DuckDBClient) applySilverMigrations() error {
 				c.config.CatalogName, c.config.SchemaName,
 			),
 		},
+		{
+			// Soroban i128/u128 token balances can exceed DECIMAL(38, 0)
+			// max — e.g. 99999999999999997748809823456034029568 fails to
+			// cast during flush. Convert to VARCHAR so the column holds
+			// arbitrary-precision values losslessly.
+			name: "address_balances_current.balance_raw -> VARCHAR",
+			sql: fmt.Sprintf(
+				`ALTER TABLE %s.%s.address_balances_current ALTER COLUMN balance_raw SET DATA TYPE VARCHAR`,
+				c.config.CatalogName, c.config.SchemaName,
+			),
+		},
 	}
 
 	for _, m := range migrations {
@@ -139,6 +150,11 @@ var tablesWithLedgerRange = map[string]bool{
 	"contract_invocations_raw":            true,
 	"effects":                             true,
 	"evicted_keys":                        true,
+	"trades":                              true,
+	"restored_keys":                       true,
+	"native_balances_current":             true,
+	"ttl_current":                         true,
+	// address_balances_current has no ledger_range column — deliberately omitted
 }
 
 // partitionSilverTables adds DuckLake partitioning to Silver tables that have ledger_range

--- a/obsrvr-lake/silver-cold-flusher/schema/silver_schema.sql
+++ b/obsrvr-lake/silver-cold-flusher/schema/silver_schema.sql
@@ -627,3 +627,89 @@ CREATE TABLE IF NOT EXISTS testnet_catalog.silver.evicted_keys (
     inserted_at TIMESTAMP
 );
 
+CREATE TABLE IF NOT EXISTS testnet_catalog.silver.trades (
+    ledger_sequence BIGINT,
+    transaction_hash VARCHAR,
+    operation_index INTEGER,
+    trade_index INTEGER,
+    trade_type VARCHAR,
+    trade_timestamp TIMESTAMP,
+    seller_account VARCHAR,
+    selling_asset_code VARCHAR,
+    selling_asset_issuer VARCHAR,
+    selling_amount BIGINT,
+    buyer_account VARCHAR,
+    buying_asset_code VARCHAR,
+    buying_asset_issuer VARCHAR,
+    buying_amount BIGINT,
+    price DECIMAL(38, 10),
+    created_at TIMESTAMP,
+    ledger_range BIGINT,
+    inserted_at TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS testnet_catalog.silver.restored_keys (
+    contract_id VARCHAR,
+    key_hash VARCHAR,
+    ledger_sequence BIGINT,
+    closed_at TIMESTAMP,
+    created_at TIMESTAMP,
+    ledger_range BIGINT,
+    inserted_at TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS testnet_catalog.silver.native_balances_current (
+    account_id VARCHAR,
+    balance BIGINT,
+    buying_liabilities BIGINT,
+    selling_liabilities BIGINT,
+    num_subentries INTEGER,
+    num_sponsoring INTEGER,
+    num_sponsored INTEGER,
+    sequence_number BIGINT,
+    last_modified_ledger BIGINT,
+    ledger_sequence BIGINT,
+    ledger_range BIGINT,
+    inserted_at TIMESTAMP,
+    updated_at TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS testnet_catalog.silver.ttl_current (
+    key_hash VARCHAR,
+    live_until_ledger_seq BIGINT,
+    ttl_remaining INTEGER,
+    expired BOOLEAN,
+    last_modified_ledger BIGINT,
+    ledger_sequence BIGINT,
+    closed_at TIMESTAMP,
+    created_at TIMESTAMP,
+    ledger_range BIGINT,
+    updated_at TIMESTAMP
+);
+
+-- address_balances_current has NO ledger_range column — intentional omission
+-- in the partitioning whitelist in silver_schema.go. Uses last_updated_ledger
+-- as its flush watermark (custom, see flusher.go customWatermarkCol).
+--
+-- balance_raw is VARCHAR (not DECIMAL) because Soroban i128/u128 token
+-- balances can exceed DECIMAL(38, 0) max. Observed failing value during
+-- initial rollout: 99999999999999997748809823456034029568 (right at the
+-- 38-digit boundary where DuckDB's cast conservatively rejects). VARCHAR
+-- preserves full precision; downstream Go can parse to big.Int if needed.
+CREATE TABLE IF NOT EXISTS testnet_catalog.silver.address_balances_current (
+    owner_address VARCHAR,
+    asset_key VARCHAR,
+    asset_type VARCHAR,
+    token_contract_id VARCHAR,
+    asset_code VARCHAR,
+    asset_issuer VARCHAR,
+    symbol VARCHAR,
+    decimals INTEGER,
+    balance_raw VARCHAR,
+    balance_display VARCHAR,
+    balance_source VARCHAR,
+    last_updated_ledger BIGINT,
+    last_updated_at TIMESTAMP,
+    updated_at TIMESTAMP
+);
+

--- a/obsrvr-lake/silver-realtime-transformer/go/bronze_cold_reader.go
+++ b/obsrvr-lake/silver-realtime-transformer/go/bronze_cold_reader.go
@@ -428,6 +428,77 @@ func (r *BronzeColdReader) QueryTokenTransfers(ctx context.Context, startLedger,
 	return rows, nil
 }
 
+// QueryUnmatchedTokenLikeContractEvents returns token-like Soroban contract
+// events whose payload shape is not currently supported by token_transfers_raw.
+func (r *BronzeColdReader) QueryUnmatchedTokenLikeContractEvents(ctx context.Context, startLedger, endLedger int64) (*sql.Rows, error) {
+	query := fmt.Sprintf(`
+		WITH token_like AS (
+			SELECT
+				e.closed_at AS timestamp,
+				e.transaction_hash,
+				e.ledger_sequence,
+				e.contract_id,
+				e.event_index,
+				json_extract_string(e.topics_decoded, '$[0]') AS event_name,
+				e.topics_decoded AS topics_decoded,
+				e.data_decoded AS data_decoded,
+				e.successful,
+				CASE
+					WHEN json_extract_string(e.topics_decoded, '$[0]') = 'transfer' THEN json_extract_string(e.topics_decoded, '$[1].address')
+					WHEN json_extract_string(e.topics_decoded, '$[0]') IN ('burn', 'clawback') THEN json_extract_string(e.topics_decoded, '$[1].address')
+				END AS parsed_from_account,
+				CASE
+					WHEN json_extract_string(e.topics_decoded, '$[0]') = 'transfer' THEN json_extract_string(e.topics_decoded, '$[2].address')
+					WHEN json_extract_string(e.topics_decoded, '$[0]') = 'mint' AND json_type(e.topics_decoded, '$[2]') = 'OBJECT'
+						THEN json_extract_string(e.topics_decoded, '$[2].address')
+					WHEN json_extract_string(e.topics_decoded, '$[0]') = 'mint' AND json_type(e.topics_decoded, '$[1]') = 'OBJECT'
+						AND json_extract_string(e.topics_decoded, '$[1].type') = 'account'
+						THEN json_extract_string(e.topics_decoded, '$[1].address')
+				END AS parsed_to_account,
+				COALESCE(
+					json_extract_string(e.data_decoded, '$.value'),
+					json_extract_string(e.data_decoded, '$.entries.amount.value')
+				) AS parsed_amount
+			FROM %s e
+			WHERE e.ledger_sequence BETWEEN $1 AND $2
+			  AND e.event_type = 'contract'
+			  AND e.topic_count >= 2
+			  AND json_extract_string(e.topics_decoded, '$[0]') IN ('transfer', 'mint', 'burn', 'clawback')
+		)
+		SELECT
+			timestamp,
+			transaction_hash,
+			ledger_sequence,
+			contract_id,
+			event_index,
+			event_name,
+			topics_decoded,
+			data_decoded,
+			successful,
+			CASE
+				WHEN event_name = 'transfer' THEN 'unsupported_transfer_shape'
+				WHEN event_name = 'mint' THEN 'unsupported_mint_shape'
+				WHEN event_name = 'burn' THEN 'unsupported_burn_shape'
+				WHEN event_name = 'clawback' THEN 'unsupported_clawback_shape'
+				ELSE 'unparseable_token_like_event'
+			END AS parse_reason
+		FROM token_like
+		WHERE NOT (
+			(event_name = 'transfer' AND parsed_from_account IS NOT NULL AND parsed_to_account IS NOT NULL AND parsed_amount IS NOT NULL)
+			OR (event_name = 'mint' AND parsed_to_account IS NOT NULL AND parsed_amount IS NOT NULL)
+			OR (event_name IN ('burn', 'clawback') AND parsed_from_account IS NOT NULL AND parsed_amount IS NOT NULL)
+		)
+		ORDER BY ledger_sequence, transaction_hash, event_index
+	`, r.tableName("contract_events_stream_v1"))
+
+	rows, err := r.db.QueryContext(ctx, query, startLedger, endLedger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query unmatched token-like contract events from cold: %w", err)
+	}
+
+	return rows, nil
+}
+
 // =============================================================================
 // Phase 2: State Tables (Accounts, Trustlines, Offers)
 // =============================================================================

--- a/obsrvr-lake/silver-realtime-transformer/go/bronze_reader.go
+++ b/obsrvr-lake/silver-realtime-transformer/go/bronze_reader.go
@@ -446,6 +446,83 @@ func (br *BronzeReader) QueryTokenTransfers(ctx context.Context, startLedger, en
 	return rows, nil
 }
 
+// QueryUnmatchedTokenLikeContractEvents returns token-like Soroban contract
+// events we intentionally preserve but cannot confidently normalize into
+// token_transfers_raw semantics.
+func (br *BronzeReader) QueryUnmatchedTokenLikeContractEvents(ctx context.Context, startLedger, endLedger int64) (*sql.Rows, error) {
+	query := `
+		WITH token_like AS (
+			SELECT
+				e.closed_at AS timestamp,
+				e.transaction_hash,
+				e.ledger_sequence,
+				e.contract_id,
+				e.event_index,
+				replace(e.topics_decoded, '\u0000', '')::jsonb->>0 AS event_name,
+				replace(e.topics_decoded, '\u0000', '') AS topics_decoded,
+				replace(e.data_decoded, '\u0000', '') AS data_decoded,
+				e.successful,
+				CASE
+					WHEN replace(e.topics_decoded, '\u0000', '')::jsonb->>0 = 'transfer' THEN
+						replace(e.topics_decoded, '\u0000', '')::jsonb->1->>'address'
+					WHEN replace(e.topics_decoded, '\u0000', '')::jsonb->>0 IN ('burn', 'clawback') THEN
+						replace(e.topics_decoded, '\u0000', '')::jsonb->1->>'address'
+				END AS parsed_from_account,
+				CASE
+					WHEN replace(e.topics_decoded, '\u0000', '')::jsonb->>0 = 'transfer' THEN
+						replace(e.topics_decoded, '\u0000', '')::jsonb->2->>'address'
+					WHEN replace(e.topics_decoded, '\u0000', '')::jsonb->>0 = 'mint'
+						AND jsonb_typeof(replace(e.topics_decoded, '\u0000', '')::jsonb->2) = 'object' THEN
+						replace(e.topics_decoded, '\u0000', '')::jsonb->2->>'address'
+					WHEN replace(e.topics_decoded, '\u0000', '')::jsonb->>0 = 'mint'
+						AND jsonb_typeof(replace(e.topics_decoded, '\u0000', '')::jsonb->1) = 'object'
+						AND (replace(e.topics_decoded, '\u0000', '')::jsonb->1->>'type') = 'account' THEN
+						replace(e.topics_decoded, '\u0000', '')::jsonb->1->>'address'
+				END AS parsed_to_account,
+				COALESCE(
+					replace(e.data_decoded, '\u0000', '')::jsonb->>'value',
+					replace(e.data_decoded, '\u0000', '')::jsonb->'entries'->'amount'->>'value'
+				) AS parsed_amount
+			FROM contract_events_stream_v1 e
+			WHERE e.ledger_sequence BETWEEN $1 AND $2
+			  AND e.event_type = 'contract'
+			  AND e.topic_count >= 2
+			  AND replace(e.topics_decoded, '\u0000', '')::jsonb->>0 IN ('transfer', 'mint', 'burn', 'clawback')
+		)
+		SELECT
+			timestamp,
+			transaction_hash,
+			ledger_sequence,
+			contract_id,
+			event_index,
+			event_name,
+			topics_decoded,
+			data_decoded,
+			successful,
+			CASE
+				WHEN event_name = 'transfer' THEN 'unsupported_transfer_shape'
+				WHEN event_name = 'mint' THEN 'unsupported_mint_shape'
+				WHEN event_name = 'burn' THEN 'unsupported_burn_shape'
+				WHEN event_name = 'clawback' THEN 'unsupported_clawback_shape'
+				ELSE 'unparseable_token_like_event'
+			END AS parse_reason
+		FROM token_like
+		WHERE NOT (
+			(event_name = 'transfer' AND parsed_from_account IS NOT NULL AND parsed_to_account IS NOT NULL AND parsed_amount IS NOT NULL)
+			OR (event_name = 'mint' AND parsed_to_account IS NOT NULL AND parsed_amount IS NOT NULL)
+			OR (event_name IN ('burn', 'clawback') AND parsed_from_account IS NOT NULL AND parsed_amount IS NOT NULL)
+		)
+		ORDER BY ledger_sequence, transaction_hash, event_index
+	`
+
+	rows, err := br.db.QueryContext(ctx, query, startLedger, endLedger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query unmatched token-like contract events: %w", err)
+	}
+
+	return rows, nil
+}
+
 // QueryAccountsSnapshot reads accounts from bronze hot snapshot for a ledger range
 // Uses the latest state for each account in the range (deduplicated)
 func (br *BronzeReader) QueryAccountsSnapshot(ctx context.Context, startLedger, endLedger int64) (*sql.Rows, error) {

--- a/obsrvr-lake/silver-realtime-transformer/go/schema/init_silver_hot_complete.sql
+++ b/obsrvr-lake/silver-realtime-transformer/go/schema/init_silver_hot_complete.sql
@@ -219,6 +219,35 @@ CREATE INDEX IF NOT EXISTS idx_token_transfers_asset ON token_transfers_raw(asse
 CREATE INDEX IF NOT EXISTS idx_token_transfers_contract ON token_transfers_raw(token_contract_id);
 CREATE INDEX IF NOT EXISTS idx_token_transfers_ledger ON token_transfers_raw(ledger_sequence);
 
+-- Table: contract_events_unmatched
+-- Token-like Soroban contract events we intentionally preserve but could not
+-- normalize into token_transfers_raw with validated semantics.
+CREATE TABLE IF NOT EXISTS contract_events_unmatched (
+    timestamp TIMESTAMP NOT NULL,
+    transaction_hash VARCHAR(64) NOT NULL,
+    ledger_sequence BIGINT NOT NULL,
+    contract_id VARCHAR(100),
+    event_index INTEGER,
+    event_name VARCHAR(64),
+    topics_decoded TEXT,
+    data_decoded TEXT,
+    successful BOOLEAN,
+    parse_reason TEXT,
+    inserted_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_contract_events_unmatched_unique
+ON contract_events_unmatched(
+    transaction_hash,
+    ledger_sequence,
+    COALESCE(event_index, -1)
+);
+
+CREATE INDEX IF NOT EXISTS idx_contract_events_unmatched_contract ON contract_events_unmatched(contract_id);
+CREATE INDEX IF NOT EXISTS idx_contract_events_unmatched_event_name ON contract_events_unmatched(event_name);
+CREATE INDEX IF NOT EXISTS idx_contract_events_unmatched_ledger ON contract_events_unmatched(ledger_sequence);
+CREATE INDEX IF NOT EXISTS idx_contract_events_unmatched_timestamp ON contract_events_unmatched(timestamp DESC);
+
 -- ============================================================================
 -- PHASE 1: CURRENT STATE TABLES (10 tables) - Starting with 5 most important
 -- ============================================================================

--- a/obsrvr-lake/silver-realtime-transformer/go/silver_writer.go
+++ b/obsrvr-lake/silver-realtime-transformer/go/silver_writer.go
@@ -222,6 +222,39 @@ func (sw *SilverWriter) WriteTokenTransfer(ctx context.Context, tx *sql.Tx, row 
 	return nil
 }
 
+// WriteUnmatchedContractEvent preserves a token-like contract event that could
+// not be safely normalized into token_transfers_raw.
+func (sw *SilverWriter) WriteUnmatchedContractEvent(ctx context.Context, tx *sql.Tx, row *UnmatchedContractEventRow) error {
+	if row.ContractID.Valid && row.ContractID.String != "" {
+		encoded, err := hexToStrKey(row.ContractID.String)
+		if err != nil {
+			return fmt.Errorf("failed to convert unmatched contract ID to strkey: %w", err)
+		}
+		row.ContractID.String = encoded
+	}
+
+	query := `
+		INSERT INTO contract_events_unmatched (
+			timestamp, transaction_hash, ledger_sequence, contract_id,
+			event_index, event_name, topics_decoded, data_decoded,
+			successful, parse_reason
+		) VALUES (
+			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10
+		)
+		ON CONFLICT DO NOTHING
+	`
+
+	_, err := tx.ExecContext(ctx, query,
+		row.Timestamp, row.TransactionHash, row.LedgerSequence, row.ContractID,
+		row.EventIndex, row.EventName, row.TopicsDecoded, row.DataDecoded,
+		row.Successful, row.ParseReason,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to write unmatched contract event: %w", err)
+	}
+	return nil
+}
+
 // WriteAccountCurrent upserts an account current state row
 func (sw *SilverWriter) WriteAccountCurrent(ctx context.Context, tx *sql.Tx, row *AccountCurrentRow) error {
 	query := `

--- a/obsrvr-lake/silver-realtime-transformer/go/silver_writer_batch.go
+++ b/obsrvr-lake/silver-realtime-transformer/go/silver_writer_batch.go
@@ -166,6 +166,14 @@ var tokenTransferColumns = []string{
 
 const tokenTransferConflict = `ON CONFLICT DO NOTHING`
 
+var unmatchedContractEventColumns = []string{
+	"timestamp", "transaction_hash", "ledger_sequence", "contract_id",
+	"event_index", "event_name", "topics_decoded", "data_decoded",
+	"successful", "parse_reason",
+}
+
+const unmatchedContractEventConflict = `ON CONFLICT DO NOTHING`
+
 var accountSnapshotColumns = []string{
 	"account_id", "ledger_sequence", "closed_at", "balance", "sequence_number",
 	"num_subentries", "num_sponsoring", "num_sponsored", "home_domain",

--- a/obsrvr-lake/silver-realtime-transformer/go/source_manager.go
+++ b/obsrvr-lake/silver-realtime-transformer/go/source_manager.go
@@ -332,6 +332,21 @@ func (sm *SourceManager) QueryTokenTransfers(ctx context.Context, startLedger, e
 	return nil, fmt.Errorf("unknown source mode: %s", mode)
 }
 
+// QueryUnmatchedTokenLikeContractEvents delegates to the appropriate reader.
+func (sm *SourceManager) QueryUnmatchedTokenLikeContractEvents(ctx context.Context, startLedger, endLedger int64) (*sql.Rows, error) {
+	sm.mu.RLock()
+	mode := sm.mode
+	sm.mu.RUnlock()
+
+	switch mode {
+	case SourceModeHot:
+		return sm.hotReader.QueryUnmatchedTokenLikeContractEvents(ctx, startLedger, endLedger)
+	case SourceModeBackfill:
+		return sm.coldReader.QueryUnmatchedTokenLikeContractEvents(ctx, startLedger, endLedger)
+	}
+	return nil, fmt.Errorf("unknown source mode: %s", mode)
+}
+
 // QueryAccountsSnapshot delegates to the appropriate reader
 func (sm *SourceManager) QueryAccountsSnapshot(ctx context.Context, startLedger, endLedger int64) (*sql.Rows, error) {
 	sm.mu.RLock()

--- a/obsrvr-lake/silver-realtime-transformer/go/transformer.go
+++ b/obsrvr-lake/silver-realtime-transformer/go/transformer.go
@@ -376,7 +376,11 @@ func (rt *RealtimeTransformer) migrateSorobanTransfers() {
 	//       SAC balances (including newly-decoded native XLM entries from the
 	//       ingester fix) land in address_balances_current without waiting
 	//       for new on-chain activity per wallet.
-	const currentMigrationVersion = 5
+	//   v6: 2026-04-19 — stop treating null/null/null Soroban rows as a reason
+	//       to rebuild all history on restart. Preserve unsupported token-like
+	//       contract events in contract_events_unmatched and only write
+	//       validated token semantics to token_transfers_raw.
+	const currentMigrationVersion = 6
 
 	// Ensure migration-tracking table exists.
 	if _, err := rt.silverDB.ExecContext(ctx, `
@@ -390,7 +394,7 @@ func (rt *RealtimeTransformer) migrateSorobanTransfers() {
 		return
 	}
 
-	// Check if migration is needed: event_index column must exist AND no soroban rows with NULL from_account
+	// Check if migration is needed: event_index column must exist.
 	var colExists bool
 	err := rt.silverDB.QueryRowContext(ctx, `
 		SELECT EXISTS (
@@ -413,7 +417,6 @@ func (rt *RealtimeTransformer) migrateSorobanTransfers() {
 	}
 
 	if colExists && appliedVersion >= currentMigrationVersion {
-		// Check if there are stale soroban rows (NULL from_account indicates unparsed)
 		var staleCount int64
 		err := rt.silverDB.QueryRowContext(ctx, `
 			SELECT COUNT(*) FROM token_transfers_raw
@@ -423,11 +426,11 @@ func (rt *RealtimeTransformer) migrateSorobanTransfers() {
 			log.Printf("⚠️  Soroban migration: failed to check stale rows: %v", err)
 			return
 		}
-		if staleCount == 0 {
-			log.Printf("ℹ️  Soroban migration: already complete at v%d, skipping", appliedVersion)
-			return
+		if staleCount > 0 {
+			log.Printf("⚠️  Soroban migration: found %d legacy null Soroban rows, but will not trigger a full rebuild at v%d", staleCount, appliedVersion)
 		}
-		log.Printf("🔄 Soroban migration: found %d stale soroban rows, re-running backfill", staleCount)
+		log.Printf("ℹ️  Soroban migration: already complete at v%d, skipping", appliedVersion)
+		return
 	} else if colExists && appliedVersion < currentMigrationVersion {
 		log.Printf("🔄 Soroban migration: applied=v%d, current=v%d — re-running backfill with fixed query", appliedVersion, currentMigrationVersion)
 	} else {
@@ -489,7 +492,18 @@ func (rt *RealtimeTransformer) migrateSorobanTransfers() {
 	}
 	deletedFlows, _ := result.RowsAffected()
 
-	log.Printf("🗑️  Soroban migration: deleted %d stale transfers, %d stale semantic flows", deletedTransfers, deletedFlows)
+	// Step 5b: Delete preserved unmatched token-like events so the backfill can
+	// repopulate them deterministically with the current parser rules.
+	result, err = rt.silverDB.ExecContext(ctx, `
+		DELETE FROM contract_events_unmatched
+		WHERE event_name IN ('transfer', 'mint', 'burn', 'clawback')
+	`)
+	if err != nil {
+		log.Printf("⚠️  Soroban migration: failed to delete unmatched token-like contract events: %v", err)
+	}
+	deletedUnmatched, _ := result.RowsAffected()
+
+	log.Printf("🗑️  Soroban migration: deleted %d stale transfers, %d stale semantic flows, %d preserved unmatched token-like events", deletedTransfers, deletedFlows, deletedUnmatched)
 
 	// Step 6: Backfill from bronze hot using JSON extraction
 	// Get the current ledger range in bronze hot
@@ -583,6 +597,7 @@ func (rt *RealtimeTransformer) migrateSorobanTransfers() {
 	// Use direct query approach: read from bronze hot, write to silver hot
 	const batchSize int64 = 5000
 	var totalInserted int64
+	var totalUnmatched int64
 
 	for batchStart := minLedger; batchStart <= maxLedger; batchStart += batchSize {
 		batchEnd := batchStart + batchSize - 1
@@ -618,8 +633,8 @@ func (rt *RealtimeTransformer) migrateSorobanTransfers() {
 				break
 			}
 
-			// Only backfill soroban rows
-			if row.SourceType != "soroban" {
+			// Only backfill validated soroban semantic rows.
+			if row.SourceType != "soroban" || !isValidTokenTransferSemantic(row) {
 				continue
 			}
 
@@ -649,9 +664,59 @@ func (rt *RealtimeTransformer) migrateSorobanTransfers() {
 			continue
 		}
 		totalInserted += batchCount
+
+		unmatchedRows, err := bronzeHotReader.QueryUnmatchedTokenLikeContractEvents(ctx, batchStart, batchEnd)
+		if err != nil {
+			log.Printf("⚠️  Soroban migration: failed to query unmatched token-like events for batch %d-%d: %v", batchStart, batchEnd, err)
+			continue
+		}
+
+		unmatchedTx, err := rt.silverDB.BeginTx(ctx, nil)
+		if err != nil {
+			unmatchedRows.Close()
+			log.Printf("⚠️  Soroban migration: failed to begin tx for unmatched batch %d-%d: %v", batchStart, batchEnd, err)
+			continue
+		}
+
+		unmatchedCount := int64(0)
+		unmatchedFailed := false
+		for unmatchedRows.Next() {
+			row := &UnmatchedContractEventRow{}
+			if err := unmatchedRows.Scan(
+				&row.Timestamp, &row.TransactionHash, &row.LedgerSequence, &row.ContractID,
+				&row.EventIndex, &row.EventName, &row.TopicsDecoded, &row.DataDecoded,
+				&row.Successful, &row.ParseReason,
+			); err != nil {
+				log.Printf("⚠️  Soroban migration: unmatched scan error in batch %d-%d: %v", batchStart, batchEnd, err)
+				unmatchedFailed = true
+				break
+			}
+			if err := rt.silverWriter.WriteUnmatchedContractEvent(ctx, unmatchedTx, row); err != nil {
+				log.Printf("⚠️  Soroban migration: unmatched write error in batch %d-%d: %v", batchStart, batchEnd, err)
+				unmatchedFailed = true
+				break
+			}
+			unmatchedCount++
+		}
+		unmatchedRows.Close()
+		if err := unmatchedRows.Err(); err != nil {
+			log.Printf("⚠️  Soroban migration: unmatched rows iteration error in batch %d-%d: %v", batchStart, batchEnd, err)
+			unmatchedFailed = true
+		}
+		if unmatchedFailed {
+			if rbErr := unmatchedTx.Rollback(); rbErr != nil {
+				log.Printf("⚠️  Soroban migration: unmatched rollback error for batch %d-%d: %v", batchStart, batchEnd, rbErr)
+			}
+			continue
+		}
+		if err := unmatchedTx.Commit(); err != nil {
+			log.Printf("⚠️  Soroban migration: unmatched commit error for batch %d-%d: %v", batchStart, batchEnd, err)
+			continue
+		}
+		totalUnmatched += unmatchedCount
 	}
 
-	log.Printf("✅ Soroban migration: backfilled %d SEP-41 token transfer events from bronze hot", totalInserted)
+	log.Printf("✅ Soroban migration: backfilled %d SEP-41 token transfer events from bronze hot and preserved %d unmatched token-like contract events", totalInserted, totalUnmatched)
 
 	// Step 7: Rebuild semantic_flows_value for the backfilled ledger range
 	if totalInserted > 0 {
@@ -818,6 +883,7 @@ func (rt *RealtimeTransformer) runTransformationCycle() error {
 	bronzeTransforms := []transformJob{
 		{"enriched_operations", rt.transformEnrichedOperations},
 		{"token_transfers", rt.transformTokenTransfers},
+		{"contract_events_unmatched", rt.transformUnmatchedTokenLikeContractEvents},
 		{"accounts_current", rt.transformAccountsCurrent},
 		{"trustlines_current", rt.transformTrustlinesCurrent},
 		{"offers_current", rt.transformOffersCurrent},
@@ -1207,6 +1273,26 @@ func (rt *RealtimeTransformer) transformEnrichedOperations(ctx context.Context, 
 	return count, nil
 }
 
+func isValidTokenTransferSemantic(row *TokenTransferRow) bool {
+	if row == nil {
+		return false
+	}
+	if row.SourceType != "soroban" {
+		return true
+	}
+	if !row.TokenContractID.Valid || row.TokenContractID.String == "" || !row.Amount.Valid || row.Amount.String == "" {
+		return false
+	}
+	fromValid := row.FromAccount.Valid && row.FromAccount.String != ""
+	toValid := row.ToAccount.Valid && row.ToAccount.String != ""
+
+	// Supported Soroban semantic shapes:
+	//   transfer: from + to + amount
+	//   mint:     to + amount
+	//   burn / clawback: from + amount
+	return (fromValid && toValid) || (!fromValid && toValid) || (fromValid && !toValid)
+}
+
 // transformTokenTransfers transforms token transfers for the ledger range
 func (rt *RealtimeTransformer) transformTokenTransfers(ctx context.Context, tx *sql.Tx, startLedger, endLedger int64) (int64, error) {
 	rows, err := rt.sourceManager.QueryTokenTransfers(ctx, startLedger, endLedger)
@@ -1241,6 +1327,10 @@ func (rt *RealtimeTransformer) transformTokenTransfers(ctx context.Context, tx *
 			row.TokenContractID.String = encoded
 		}
 
+		if !isValidTokenTransferSemantic(row) {
+			continue
+		}
+
 		if err := batch.Add(row.Values()...); err != nil {
 			return count, fmt.Errorf("failed to add token transfer to batch: %w", err)
 		}
@@ -1257,6 +1347,55 @@ func (rt *RealtimeTransformer) transformTokenTransfers(ctx context.Context, tx *
 
 	if err := batch.Flush(ctx, tx); err != nil {
 		return count, fmt.Errorf("failed to flush token transfers remainder: %w", err)
+	}
+
+	return count, nil
+}
+
+// transformUnmatchedTokenLikeContractEvents preserves token-like Soroban
+// contract events that could not be safely normalized into token_transfers_raw.
+func (rt *RealtimeTransformer) transformUnmatchedTokenLikeContractEvents(ctx context.Context, tx *sql.Tx, startLedger, endLedger int64) (int64, error) {
+	rows, err := rt.sourceManager.QueryUnmatchedTokenLikeContractEvents(ctx, startLedger, endLedger)
+	if err != nil {
+		return 0, err
+	}
+	defer rows.Close()
+
+	batch := NewBatchInserter("contract_events_unmatched", unmatchedContractEventColumns, unmatchedContractEventConflict, rt.insertBatchSize())
+	count := int64(0)
+
+	for rows.Next() {
+		row := &UnmatchedContractEventRow{}
+		if err := rows.Scan(
+			&row.Timestamp, &row.TransactionHash, &row.LedgerSequence, &row.ContractID,
+			&row.EventIndex, &row.EventName, &row.TopicsDecoded, &row.DataDecoded,
+			&row.Successful, &row.ParseReason,
+		); err != nil {
+			return count, fmt.Errorf("failed to scan unmatched contract event row: %w", err)
+		}
+
+		if row.ContractID.Valid && row.ContractID.String != "" {
+			encoded, err := hexToStrKey(row.ContractID.String)
+			if err != nil {
+				return count, fmt.Errorf("failed to convert unmatched contract ID to strkey: %w", err)
+			}
+			row.ContractID.String = encoded
+		}
+
+		if err := batch.Add(row.Values()...); err != nil {
+			return count, fmt.Errorf("failed to add unmatched contract event to batch: %w", err)
+		}
+		if err := batch.FlushIfNeeded(ctx, tx); err != nil {
+			return count, fmt.Errorf("failed to flush unmatched contract events batch: %w", err)
+		}
+		count++
+	}
+
+	if err := rows.Err(); err != nil {
+		return count, fmt.Errorf("error iterating unmatched contract events: %w", err)
+	}
+	if err := batch.Flush(ctx, tx); err != nil {
+		return count, fmt.Errorf("failed to flush unmatched contract events remainder: %w", err)
 	}
 
 	return count, nil
@@ -2627,16 +2766,18 @@ func (rt *RealtimeTransformer) transformSemanticActivities(ctx context.Context, 
 				WHEN e.type = 0 THEN 'account_created'
 				WHEN e.type = 1 THEN 'payment'
 				WHEN e.type = 2 THEN 'path_payment'
-				WHEN e.type = 6 THEN 'path_payment'
-				WHEN e.type = 13 THEN 'path_payment'
 				WHEN e.type = 3 THEN 'manage_offer'
 				WHEN e.type = 4 THEN 'create_passive_offer'
 				WHEN e.type = 5 THEN 'set_options'
-				WHEN e.type = 7 THEN 'account_merge'
-				WHEN e.type = 8 THEN 'inflation'
-				WHEN e.type = 9 THEN 'manage_data'
-				WHEN e.type = 10 THEN 'bump_sequence'
+				WHEN e.type = 6 THEN 'change_trust'
+				WHEN e.type = 7 THEN 'allow_trust'
+				WHEN e.type = 8 THEN 'account_merge'
+				WHEN e.type = 9 THEN 'inflation'
+				WHEN e.type = 10 THEN 'manage_data'
+				WHEN e.type = 11 THEN 'bump_sequence'
 				WHEN e.type = 12 THEN 'manage_offer'
+				WHEN e.type = 13 THEN 'path_payment'
+				WHEN e.type = 21 THEN 'set_trust_line_flags'
 				WHEN e.type = 24 AND e.function_name IS NOT NULL THEN 'contract_call'
 				WHEN e.type = 24 THEN 'invoke_host_function'
 				ELSE 'other'
@@ -2644,8 +2785,14 @@ func (rt *RealtimeTransformer) transformSemanticActivities(ctx context.Context, 
 			CASE
 				WHEN e.type = 0 THEN 'Created account ' || COALESCE(e.destination, '')
 				WHEN e.type = 1 THEN 'Sent ' || COALESCE(CAST(e.amount AS TEXT), '?') || ' ' || COALESCE(e.asset_code, 'XLM') || ' to ' || COALESCE(e.destination, '')
-				WHEN e.type IN (2, 6, 13) THEN 'Path payment ' || COALESCE(CAST(e.amount AS TEXT), '?') || ' ' || COALESCE(e.asset_code, 'XLM')
-				WHEN e.type = 7 THEN 'Merged into ' || COALESCE(e.into_account, '')
+				WHEN e.type IN (2, 13) THEN 'Path payment ' || COALESCE(CAST(e.amount AS TEXT), '?') || ' ' || COALESCE(e.asset_code, 'XLM')
+				WHEN e.type = 6 THEN CASE
+					WHEN COALESCE(e.asset_code, '') <> '' THEN 'Added trustline for ' || e.asset_code
+					ELSE 'Updated trustline'
+				END
+				WHEN e.type = 7 THEN 'Updated trust authorization'
+				WHEN e.type = 8 THEN 'Merged into ' || COALESCE(e.into_account, '')
+				WHEN e.type = 21 THEN 'Updated trustline flags'
 				WHEN e.type = 24 AND e.function_name IS NOT NULL THEN 'Called ' || e.function_name || ' on ' || COALESCE(e.contract_id, '')
 				WHEN e.type = 24 THEN 'Invoked host function'
 				ELSE NULL

--- a/obsrvr-lake/silver-realtime-transformer/go/types.go
+++ b/obsrvr-lake/silver-realtime-transformer/go/types.go
@@ -159,6 +159,21 @@ type TokenTransferRow struct {
 	EventIndex            sql.NullInt32
 }
 
+// UnmatchedContractEventRow preserves token-like Soroban contract events whose
+// payload shape could not be confidently normalized into token_transfers_raw.
+type UnmatchedContractEventRow struct {
+	Timestamp       time.Time
+	TransactionHash string
+	LedgerSequence  int64
+	ContractID      sql.NullString
+	EventIndex      sql.NullInt32
+	EventName       sql.NullString
+	TopicsDecoded   sql.NullString
+	DataDecoded     sql.NullString
+	Successful      bool
+	ParseReason     string
+}
+
 // AccountCurrentRow represents a row in the accounts_current table
 type AccountCurrentRow struct {
 	AccountID           string
@@ -675,6 +690,15 @@ func (row *TokenTransferRow) Values() []interface{} {
 		row.Timestamp, row.TransactionHash, row.LedgerSequence, row.SourceType,
 		row.FromAccount, row.ToAccount, row.AssetCode, row.AssetIssuer, row.Amount,
 		row.TokenContractID, row.OperationType, row.TransactionSuccessful, row.EventIndex,
+	}
+}
+
+// Values returns the ordered column values for batch insertion into contract_events_unmatched.
+func (row *UnmatchedContractEventRow) Values() []interface{} {
+	return []interface{}{
+		row.Timestamp, row.TransactionHash, row.LedgerSequence, row.ContractID,
+		row.EventIndex, row.EventName, row.TopicsDecoded, row.DataDecoded,
+		row.Successful, row.ParseReason,
 	}
 }
 

--- a/obsrvr-lake/stellar-query-api/docs/LEDGER_SUMMARY_ENDPOINT.md
+++ b/obsrvr-lake/stellar-query-api/docs/LEDGER_SUMMARY_ENDPOINT.md
@@ -1,0 +1,526 @@
+# Ledger Summary Endpoint
+
+Purpose: define a structured ledger-level summary endpoint that can power ledger-first explorer surfaces such as Prism home page hero cards, dashboards, and analytics views.
+
+This endpoint is intended to provide:
+- ledger identity
+- transaction and operation totals
+- semantic composition counts
+- Soroban utilization metrics
+- provenance / partial-data indicators
+
+It should remain:
+- deterministic
+- structured
+- reusable by non-Prism consumers
+- free of product-specific narration
+
+---
+
+## Recommended endpoint
+
+```http
+GET /api/v1/silver/ledgers/{seq}/summary
+```
+
+### Why this route
+This route keeps the payload tied to a canonical ledger resource rather than a Prism-specific homepage concept.
+
+It is suitable for:
+- explorer home pages
+- ledger cards
+- dashboard widgets
+- API consumers who want a compact ledger summary without multiple fan-out requests
+
+---
+
+## Design goals
+
+The endpoint should let clients render UI like:
+- `ledger #52,844,201`
+- `245 transactions`
+- chips like `68 swaps`, `86 calls`, `39 agents`
+- utilization bars like `instructions 64%`, `read / write 60%`
+
+without requiring multiple follow-up requests.
+
+---
+
+## Response shape
+
+### Example response
+
+```json
+{
+  "ledger": {
+    "sequence": 52844201,
+    "closed_at": "2026-04-17T18:46:53Z",
+    "protocol_version": 23,
+    "hash": "abc123...",
+    "previous_hash": "def456..."
+  },
+  "totals": {
+    "transaction_count": 245,
+    "successful_tx_count": 231,
+    "failed_tx_count": 14,
+    "operation_count": 612,
+    "contract_event_count": 98,
+    "soroban_op_count": 141,
+    "total_fee_charged": 128400
+  },
+  "classification_counts": {
+    "swap_tx_count": 68,
+    "contract_call_tx_count": 86,
+    "agent_tx_count": 39,
+    "payment_tx_count": 22,
+    "wallet_tx_count": 14,
+    "deployment_tx_count": 3,
+    "classic_tx_count": 104,
+    "soroban_tx_count": 141
+  },
+  "soroban_utilization": {
+    "instructions_used": 384000000,
+    "instructions_limit": 600000000,
+    "instructions_pct": 64,
+    "read_bytes_used": 210000,
+    "write_bytes_used": 150000,
+    "read_write_bytes_used": 360000,
+    "read_write_bytes_limit": 600000,
+    "read_write_pct": 60,
+    "rent_burned": 24.8
+  },
+  "composition": {
+    "dominant_tx_type": "contract_call",
+    "dominant_tx_type_count": 86,
+    "soroban_share_pct": 58,
+    "failed_share_pct": 6
+  },
+  "provenance": {
+    "classification_source": "semantic_tx_materialized_v1",
+    "utilization_source": "ledger_soroban_aggregates_v1",
+    "partial": false
+  }
+}
+```
+
+---
+
+## Field definitions
+
+## `ledger`
+Canonical ledger identity fields.
+
+```json
+"ledger": {
+  "sequence": 52844201,
+  "closed_at": "2026-04-17T18:46:53Z",
+  "protocol_version": 23,
+  "hash": "...",
+  "previous_hash": "..."
+}
+```
+
+### Required
+- `sequence`
+- `closed_at`
+
+### Optional but recommended
+- `protocol_version`
+- `hash`
+- `previous_hash`
+
+---
+
+## `totals`
+Base ledger metrics.
+
+```json
+"totals": {
+  "transaction_count": 245,
+  "successful_tx_count": 231,
+  "failed_tx_count": 14,
+  "operation_count": 612,
+  "contract_event_count": 98,
+  "soroban_op_count": 141,
+  "total_fee_charged": 128400
+}
+```
+
+### Required
+- `transaction_count`
+
+### Strongly recommended
+- `successful_tx_count`
+- `failed_tx_count`
+- `operation_count`
+- `soroban_op_count`
+
+### Optional
+- `contract_event_count`
+- `total_fee_charged`
+
+---
+
+## `classification_counts`
+Per-ledger transaction composition counts. These power UI chips and analytics summaries.
+
+```json
+"classification_counts": {
+  "swap_tx_count": 68,
+  "contract_call_tx_count": 86,
+  "agent_tx_count": 39,
+  "payment_tx_count": 22,
+  "wallet_tx_count": 14,
+  "deployment_tx_count": 3,
+  "classic_tx_count": 104,
+  "soroban_tx_count": 141
+}
+```
+
+### Required for ledger-first explorer mock
+- `swap_tx_count`
+- `contract_call_tx_count`
+- `agent_tx_count`
+
+### Strongly recommended
+- `payment_tx_count`
+- `wallet_tx_count`
+- `deployment_tx_count`
+- `classic_tx_count`
+- `soroban_tx_count`
+
+### Important note on `agent_tx_count`
+This field must have a documented deterministic meaning.
+
+Recommended definition:
+
+> `agent_tx_count` = number of transactions in the ledger where at least one actor is classified as `agent` or `automated_actor` by the semantic transaction classifier.
+
+If the term `agent` is not considered stable enough yet, consider using:
+- `automated_actor_tx_count`
+
+and letting downstream applications label it as “agents” if desired.
+
+---
+
+## `soroban_utilization`
+Resource usage and capacity metrics for the ledger.
+
+```json
+"soroban_utilization": {
+  "instructions_used": 384000000,
+  "instructions_limit": 600000000,
+  "instructions_pct": 64,
+  "read_bytes_used": 210000,
+  "write_bytes_used": 150000,
+  "read_write_bytes_used": 360000,
+  "read_write_bytes_limit": 600000,
+  "read_write_pct": 60,
+  "rent_burned": 24.8
+}
+```
+
+### Required for ledger-first explorer mock
+- `instructions_pct`
+- `read_write_pct`
+
+### Strongly recommended
+- `instructions_used`
+- `instructions_limit`
+- `read_bytes_used`
+- `write_bytes_used`
+- `read_write_bytes_used`
+- `read_write_bytes_limit`
+
+### Optional
+- `rent_burned`
+
+### Design note
+The API should provide:
+- raw usage
+- raw limits
+- percentages
+
+This allows clients to render:
+- bars
+- text labels
+- tooltips
+- alternate normalizations
+
+without having to guess denominators.
+
+---
+
+## `composition`
+Optional helper metrics derived from the main totals and classification counts.
+
+```json
+"composition": {
+  "dominant_tx_type": "contract_call",
+  "dominant_tx_type_count": 86,
+  "soroban_share_pct": 58,
+  "failed_share_pct": 6
+}
+```
+
+These are not required for the mock but can support richer ledger-first explorer experiences.
+
+### Optional fields
+- `dominant_tx_type`
+- `dominant_tx_type_count`
+- `soroban_share_pct`
+- `failed_share_pct`
+
+---
+
+## `provenance`
+Metadata describing where summary values came from and whether the payload is partial.
+
+```json
+"provenance": {
+  "classification_source": "semantic_tx_materialized_v1",
+  "utilization_source": "ledger_soroban_aggregates_v1",
+  "partial": false
+}
+```
+
+### Recommended fields
+- `classification_source`
+- `utilization_source`
+- `partial`
+
+### Why this matters
+This helps preserve trust when:
+- some ledgers are only partially indexed
+- some counts are approximated or lagging
+- some semantic materializations are unavailable
+
+---
+
+## Minimal viable response
+
+If implementing a minimal version first, this shape is sufficient to render the current ledger-first inspiration mock:
+
+```json
+{
+  "ledger": {
+    "sequence": 52844201,
+    "closed_at": "2026-04-17T18:46:53Z"
+  },
+  "totals": {
+    "transaction_count": 245
+  },
+  "classification_counts": {
+    "swap_tx_count": 68,
+    "contract_call_tx_count": 86,
+    "agent_tx_count": 39
+  },
+  "soroban_utilization": {
+    "instructions_pct": 64,
+    "read_write_pct": 60
+  },
+  "provenance": {
+    "partial": false
+  }
+}
+```
+
+However, the richer version is recommended for long-term reuse.
+
+---
+
+## Counting semantics
+
+## Core recommendation
+Classification counts should be based on **unique transactions per ledger**, not operation counts or event counts.
+
+### Why
+The home/hero ledger summary is intended to answer:
+- how many transactions in this ledger were swaps?
+- how many were calls?
+- how many involved agents?
+
+This is more intuitive and stable than counting raw operations or events.
+
+---
+
+## Counting model
+
+### Recommended model: non-exclusive counters
+A single transaction may increment multiple counters.
+
+Example:
+- a smart wallet swap transaction may count toward:
+  - `swap_tx_count`
+  - `contract_call_tx_count`
+  - `agent_tx_count`
+
+This model is best for ledger composition chips.
+
+### Not recommended for this use case: exclusive buckets
+Exclusive classification would force one tx into exactly one bucket, which makes the ledger less informative for multi-dimensional homepage summaries.
+
+---
+
+## Suggested classification definitions
+
+These are illustrative and should be aligned with actual semantic-layer definitions.
+
+- `swap_tx_count`
+  - count txs whose semantic classifier yields a swap-like tx type
+- `contract_call_tx_count`
+  - count txs with Soroban contract invocation / contract-call semantic classification
+- `agent_tx_count`
+  - count txs with at least one actor classified as `agent` or `automated_actor`
+- `wallet_tx_count`
+  - count txs where `wallet_involved = true`
+- `deployment_tx_count`
+  - count txs classified as deployment-like activity
+- `classic_tx_count`
+  - count txs with no Soroban call involvement or explicitly classified classic-only activity
+- `soroban_tx_count`
+  - count txs with Soroban operation involvement
+
+---
+
+## Implementation sources
+
+This endpoint should ideally be composed from three existing or near-existing sources:
+
+### 1. Ledger totals source
+Used for:
+- transaction counts
+- operation counts
+- success/fail counts
+- fee totals
+- contract event totals
+
+### 2. Semantic transaction classifications grouped by ledger
+Used for:
+- semantic composition counts
+- agent/activity counts
+- dominant tx type
+
+Materialized or pre-aggregated sources are preferred when possible.
+
+### 3. Ledger Soroban aggregate source
+Used for:
+- instructions usage
+- read/write usage
+- rent burned
+- utilization percentages
+
+Existing Soroban ledger aggregate work should be reused where possible.
+
+---
+
+## Suggested Go types
+
+```go
+type LedgerSummaryResponse struct {
+    Ledger               LedgerSummaryLedger              `json:"ledger"`
+    Totals               LedgerSummaryTotals              `json:"totals"`
+    ClassificationCounts LedgerSummaryClassifications     `json:"classification_counts"`
+    SorobanUtilization   *LedgerSummarySorobanUtilization `json:"soroban_utilization,omitempty"`
+    Composition          *LedgerSummaryComposition        `json:"composition,omitempty"`
+    Provenance           LedgerSummaryProvenance          `json:"provenance"`
+}
+
+type LedgerSummaryLedger struct {
+    Sequence        int64  `json:"sequence"`
+    ClosedAt        string `json:"closed_at"`
+    ProtocolVersion int    `json:"protocol_version,omitempty"`
+    Hash            string `json:"hash,omitempty"`
+    PreviousHash    string `json:"previous_hash,omitempty"`
+}
+
+type LedgerSummaryTotals struct {
+    TransactionCount   int64 `json:"transaction_count"`
+    SuccessfulTxCount  int64 `json:"successful_tx_count,omitempty"`
+    FailedTxCount      int64 `json:"failed_tx_count,omitempty"`
+    OperationCount     int64 `json:"operation_count,omitempty"`
+    ContractEventCount int64 `json:"contract_event_count,omitempty"`
+    SorobanOpCount     int64 `json:"soroban_op_count,omitempty"`
+    TotalFeeCharged    int64 `json:"total_fee_charged,omitempty"`
+}
+
+type LedgerSummaryClassifications struct {
+    SwapTxCount         int64 `json:"swap_tx_count,omitempty"`
+    ContractCallTxCount int64 `json:"contract_call_tx_count,omitempty"`
+    AgentTxCount        int64 `json:"agent_tx_count,omitempty"`
+    PaymentTxCount      int64 `json:"payment_tx_count,omitempty"`
+    WalletTxCount       int64 `json:"wallet_tx_count,omitempty"`
+    DeploymentTxCount   int64 `json:"deployment_tx_count,omitempty"`
+    ClassicTxCount      int64 `json:"classic_tx_count,omitempty"`
+    SorobanTxCount      int64 `json:"soroban_tx_count,omitempty"`
+}
+
+type LedgerSummarySorobanUtilization struct {
+    InstructionsUsed    int64   `json:"instructions_used,omitempty"`
+    InstructionsLimit   int64   `json:"instructions_limit,omitempty"`
+    InstructionsPct     float64 `json:"instructions_pct,omitempty"`
+    ReadBytesUsed       int64   `json:"read_bytes_used,omitempty"`
+    WriteBytesUsed      int64   `json:"write_bytes_used,omitempty"`
+    ReadWriteBytesUsed  int64   `json:"read_write_bytes_used,omitempty"`
+    ReadWriteBytesLimit int64   `json:"read_write_bytes_limit,omitempty"`
+    ReadWritePct        float64 `json:"read_write_pct,omitempty"`
+    RentBurned          float64 `json:"rent_burned,omitempty"`
+}
+
+type LedgerSummaryComposition struct {
+    DominantTxType      string  `json:"dominant_tx_type,omitempty"`
+    DominantTxTypeCount int64   `json:"dominant_tx_type_count,omitempty"`
+    SorobanSharePct     float64 `json:"soroban_share_pct,omitempty"`
+    FailedSharePct      float64 `json:"failed_share_pct,omitempty"`
+}
+
+type LedgerSummaryProvenance struct {
+    ClassificationSource string `json:"classification_source,omitempty"`
+    UtilizationSource    string `json:"utilization_source,omitempty"`
+    Partial              bool   `json:"partial"`
+}
+```
+
+---
+
+## Documentation guidance
+
+### Summary
+Returns a compact, structured ledger-level summary suitable for explorer homepages and analytics dashboards.
+
+### Description
+Provides:
+- ledger identity
+- transaction and operation totals
+- semantic transaction composition counts
+- Soroban resource utilization
+- provenance metadata
+
+Designed for deterministic rendering without client-side fan-out.
+
+---
+
+## What this endpoint should not do
+
+This endpoint should **not** include:
+- long prose descriptions
+- UI-specific labels
+- Prism-only wording
+- subjective framing such as “interesting” or “suspicious”
+- page-specific presentation fields
+
+It should remain a structured data product suitable for any consumer.
+
+---
+
+## Future extensions
+
+Possible future fields that still fit this contract:
+- top protocol in ledger
+- dominant asset moved
+- fee pressure indicators
+- anomaly counts
+- signer/admin action counts
+- wallet-family composition
+
+These should only be added if they remain deterministic and broadly reusable.

--- a/obsrvr-lake/stellar-query-api/docs/api-vs-prism-responsibility-matrix.md
+++ b/obsrvr-lake/stellar-query-api/docs/api-vs-prism-responsibility-matrix.md
@@ -1,0 +1,590 @@
+# API vs Prism Responsibility Matrix
+
+Purpose: define a durable boundary between the Obsrvr gateway/query API as a flagship developer product and Prism as an opinionated explorer application.
+
+This document is intended to help answer questions like:
+
+- What belongs in the API vs in Prism?
+- How far should semantic enrichment go before it becomes product-specific narration?
+- How do we keep the API broadly useful to builders while still making Prism highly human-readable?
+
+---
+
+## Core principle
+
+The recommended boundary is:
+
+- **Gateway/API provides structured, deterministic, composable intelligence**
+- **Prism provides narrative, presentation, and opinionated UX**
+
+In other words:
+
+- the API should be rich
+- the API should be semantic
+- the API should be explorer-friendly
+- the API should **not** become a Prism-specific prose engine
+
+---
+
+## Mental model
+
+The current semantic-layer design already points in the right direction:
+
+### Layer 1 — deterministic classification
+Machine-usable labels derived from rules, templates, heuristics, and indexed facts.
+
+Examples:
+- `tx_type`
+- `subtype`
+- `wallet_involved`
+- `effective_actor_type`
+- `contract_type`
+- `wallet_type`
+
+### Layer 2 — structured context enrichment
+Additional structured context that makes Layer 1 useful in real applications.
+
+Examples:
+- actors with roles
+- asset movement structure
+- call graph
+- token metadata
+- confidence
+- evidence
+- smart wallet provenance
+- signed diffs
+
+### Layer 3 — narration and presentation
+The final human-facing interpretation layer.
+
+Examples:
+- headlines
+- explanatory paragraphs
+- badges
+- “what stands out”
+- narrative summaries
+- product tone and voice
+
+**Recommendation:**
+- Layers 1 and 2 belong in the API
+- Layer 3 belongs in Prism
+
+---
+
+## Responsibility matrix
+
+| Concern | Bronze | Silver | Semantic | Prism |
+|---|---|---|---|---|
+| Raw chain facts | Yes | No | No | No |
+| Normalized chain facts | Limited | Yes | Yes | No |
+| Deterministic summaries | No | Yes | Yes | No |
+| Classifications | No | Light | Yes | Light consumption |
+| Confidence/evidence | No | Light | Yes | Yes, presentation layer |
+| Actor roles | No | Limited | Yes | Presented |
+| Wallet detection | No | Light/basic | Yes | Presented |
+| Natural-language narration | No | Minimal only | No | Yes |
+| Visual emphasis / badges / explorer copy | No | No | No | Yes |
+| Subjective framing / editorial tone | No | No | No | Yes |
+
+---
+
+## What the API should own
+
+### 1. Raw and canonical facts
+These are the non-negotiable building blocks that should remain first-class API data.
+
+Examples:
+- ledger sequence
+- tx hash
+- operation type
+- event type
+- effect type
+- source and destination accounts
+- contract id
+- asset code / issuer / token contract id
+- amounts
+- balances
+- signer state
+- trustline state
+
+### 2. Deterministic normalization
+These are facts that have been cleaned up, merged, or reshaped for downstream consumers.
+
+Examples:
+- unified transfers
+- signed diffs
+- decoded operations
+- receipt payloads
+- event unification
+- effect aggregation
+- wallet balance normalization
+- account activity normalization
+
+### 3. Deterministic semantic classification
+These fields add real platform value and are broadly reusable across apps.
+
+Examples:
+- `tx_type`
+- `subtype`
+- `operation_types`
+- `wallet_involved`
+- `effective_actor_type`
+- `contract_type`
+- `wallet_type`
+- `implementation`
+- `protocol hints`
+- `call_graph`
+
+### 4. Structured context enrichment
+These make the API meaning-oriented without crossing into product narration.
+
+Examples:
+- actors with roles
+- asset movement context
+- confidence
+- evidence arrays
+- involved contracts
+- observed functions
+- token metadata
+- provenance / source-of-truth fields
+- `partial` / `degraded` indicators
+
+### 5. Compact factual summaries
+Short, deterministic summaries are acceptable in the API when they are factual and mechanically derived.
+
+Examples:
+- `"Sent 0.29 DSD to GDQF...2X4D"`
+- `"Added trustline for VNM"`
+- `"Created account ... with 10,000 XLM"`
+
+These are acceptable because they are:
+- concise
+- factual
+- low-opinion
+- reusable by multiple consumers
+
+---
+
+## What Prism should own
+
+### 1. Human-readable presentation
+Prism should decide how structured facts are surfaced to end users.
+
+Examples:
+- page titles
+- section labels
+- hero cards
+- “Overview / Security / Activity” tabs
+- badge colors and iconography
+- row grouping and ordering
+
+### 2. Narrative prose
+Prism should turn structured facts into end-user-friendly narration.
+
+Examples:
+- “This transaction funded a new account...”
+- “This looks like a routine wallet interaction...”
+- “Delegated execution occurred through a smart wallet...”
+
+### 3. Subjective framing
+These are product-level decisions and should not live in the API.
+
+Examples:
+- “High confidence” label wording
+- “routine”
+- “important”
+- “suspicious”
+- “safe”
+- “likely intended”
+
+### 4. Product opinion
+Prism should decide what matters most to the user.
+
+Examples:
+- which actors are prominent
+- whether a warning should be shown
+- whether multiple transfers should collapse into one transaction row
+- whether to call something “payment” vs “transfer” in UI copy
+
+---
+
+## Endpoint-by-endpoint guidance
+
+## `/api/v1/silver/tx/{hash}/receipt`
+
+### API should own
+- tx metadata
+- decoded operations
+- events
+- effects
+- signed diffs
+- structured summary
+- semantic classification
+- actors
+- assets
+- evidence
+- source/provenance metadata
+- partial/materialized/source-version metadata
+
+### API should avoid
+- long human narratives
+- UI-oriented labels
+- Prism-specific badge text
+- editorial sections like “what stands out”
+
+### Prism should own
+- hero title
+- explanation cards
+- actor pills
+- event grouping/collapsing
+- UX copy and tone
+- fallback messaging
+
+### Recommendation
+Treat `/receipt` as the **single-call canonical structured transaction object**.
+It should be rich in facts, not rich in prose.
+
+---
+
+## `/api/v1/silver/tx/{hash}/semantic`
+
+### API should own
+- `classification`
+- `confidence`
+- actor roles
+- wallet involvement
+- effective actor type
+- assets
+- operations
+- events
+- call graph
+- optional diffs
+- legacy summary for compatibility
+
+### API should avoid
+- product voice
+- sentence-level storytelling
+- app-specific narrative framing
+
+### Prism should own
+- turning semantic fields into:
+  - narratives
+  - evidence cards
+  - actor chips
+  - “why Prism thinks this” sections
+
+### Recommendation
+This endpoint should be the flagship **structured semantic intelligence** endpoint.
+Lean hard into structure, not prose.
+
+---
+
+## `/api/v1/silver/tx/{hash}/full`
+
+### API should own
+- assembled decoded tx facts
+- structured summary
+- decoded operations and events
+- resources
+- contracts involved
+- call graph if included
+
+### API should avoid
+- becoming a Prism page JSON blob
+
+### Prism should own
+- deciding which fields matter most in UI
+- rendering details progressively
+
+---
+
+## `/api/v1/silver/smart-wallets/{contract_id}`
+
+### API should own
+- detection status
+- provenance
+- implementation
+- wallet type
+- signers if decoded
+- approval model facts
+- policy/admin activity facts
+- balance facts
+- timeline facts
+- partial/degraded flags
+
+### API should avoid
+- pretending unknown thresholds/policies are known
+- heavy narrative like “this wallet is commonly used for...”
+- UI-specific section names such as “Overview” or “Security”
+
+### Prism should own
+- section naming
+- degraded-mode messaging
+- humanized policy/admin activity text
+- visual confidence/provenance presentation
+
+### Recommendation
+Smart wallet detail should be a **structured wallet profile**, not a pre-rendered explorer experience.
+
+---
+
+## `/api/v1/silver/smart-wallets/{contract_id}/balances`
+
+### API should own
+- canonical wallet balances
+- symbol / decimals
+- balance source
+- freshness / provenance
+- partial/confidence indicators
+
+### Prism should own
+- portfolio presentation
+- sorting prominence
+- iconography
+- UI grouping
+
+---
+
+## `/api/v1/silver/accounts/{id}/activity`
+
+### API should own
+- normalized activity items
+- type/subtype
+- actor references
+- tx hash
+- timestamp / ledger
+- amount / asset
+- source-of-classification
+- confidence if useful
+
+### API should avoid
+- final UI semantics like “Security” vs “Activity” unless they are truly machine-meaningful categories
+
+### Prism should own
+- tab model
+- whether to merge account activity with wallet activity
+- human phrases like “Sent”, “Received”, “Moved within wallet”
+
+---
+
+## `/api/v1/silver/transfers`
+
+### API should own
+- transfer facts
+- directionality
+- token metadata
+- canonical identities
+- strong filtering and pagination
+
+### API should avoid
+- trying to explain user intent
+
+### Prism should own
+- grouping multiple transfer events into one human transaction row
+- feed copy
+- “transaction vs transfer event” semantics in UI
+
+---
+
+## `/api/v1/semantic/contracts`
+
+### API should own
+- `contract_type`
+- `wallet_type`
+- `observed_functions`
+- usage metrics
+- deployer/activity
+- token metadata
+
+### API should avoid
+- qualitative labels such as “popular”, “trusted”, or “important”
+
+### Prism should own
+- directory presentation
+- tags/badges
+- “Top contracts” copy
+
+---
+
+## `/api/v1/semantic/activities`
+
+### API should own
+- normalized high-level activity facts
+- actor references
+- tx type
+- assets
+- timestamp
+- evidence/confidence if available
+
+### API should avoid
+- final end-user narration
+
+### Prism should own
+- feed wording
+- grouping/collapsing
+- home page presentation
+
+---
+
+## `/api/v1/semantic/flows`
+
+### API should own
+- value movement facts
+- flow type
+- source/target identities
+- asset identities
+- amount and direction
+
+### API should avoid
+- trader/investor interpretation
+- protocol success narratives
+
+### Prism should own
+- flow visualizations
+- summaries
+- storytelling
+
+---
+
+## Field-level rule of thumb
+
+### Put a field in the API if it is:
+- deterministic
+- reproducible
+- inspectable
+- broadly useful to non-Prism consumers
+- stable under rewording
+- easier to compute near the data than in clients
+
+Examples:
+- `tx_type`
+- `subtype`
+- `confidence`
+- `actors[].roles`
+- `wallet_involved`
+- `effective_actor_type`
+- `summary.transfer`
+- `summary.swap`
+- `evidence[]`
+- `partial`
+- `source_of_truth`
+
+### Put a field in Prism if it is:
+- prose
+- UI-oriented
+- product-voice-heavy
+- audience-specific
+- likely to vary by application
+
+Examples:
+- `human_title`
+- `human_narrative`
+- `signals`
+- `what_stands_out`
+- `severity_label`
+- `hero_copy`
+- `badge_text`
+- `trust_message`
+
+---
+
+## Good additions to gateway
+
+These are examples of fields and concepts that strengthen the flagship API without making it too subjective:
+
+- `evidence`
+- `confidence`
+- `actors`
+- `assets`
+- `call_graph`
+- `wallet_type`
+- `implementation`
+- `partial`
+- `source_version`
+- `source_of_truth`
+- structured `summary.transfer`
+- structured `summary.swap`
+- structured `summary.mint`
+- structured `summary.burn`
+- signed `diffs`
+- normalized effects
+
+---
+
+## Risky additions to gateway
+
+These are examples of fields that likely belong in Prism instead:
+
+- `human_title`
+- `human_narrative`
+- `signals`
+- `what_stands_out`
+- `risk_label`
+- `routine_activity`
+- `suspicious`
+- `important`
+- long friendly descriptions with product voice
+
+---
+
+## Product positioning recommendation
+
+The flagship API should aim to provide:
+
+- **canonical facts**
+- **normalized entities**
+- **deterministic classifications**
+- **structured semantic context**
+- **portable evidence**
+
+Prism should aim to provide:
+
+- **human explanation**
+- **opinionated simplification**
+- **narrative**
+- **UI semantics**
+- **editorial emphasis**
+
+This keeps the API broadly useful to builders while allowing Prism to be the most human-readable explorer possible.
+
+---
+
+## Acceptance checklist for new API fields
+
+When adding a new field to the gateway/query API, check whether it satisfies at least one of these:
+
+1. Useful to non-Prism consumers
+2. Deterministic and reproducible
+3. Easier to compute near the data than in clients
+4. Structured rather than editorial
+5. Improves correctness, not just friendliness
+
+If a proposed field does **not** satisfy any of these, it probably belongs in Prism instead.
+
+---
+
+## Short-form summary
+
+| Category | Gateway/API | Prism |
+|---|---|---|
+| Facts | Owns | Consumes |
+| Normalization | Owns | Consumes |
+| Classification | Owns | Consumes/interprets |
+| Evidence/confidence | Owns | Displays |
+| Narration | Avoid | Owns |
+| UX labels/badges | Avoid | Owns |
+| Subjective framing | Avoid | Owns |
+
+---
+
+## Final guidance
+
+A premium API does **not** have to be raw-only.
+
+The right target is:
+- rich semantics
+- strong normalization
+- deterministic interpretation
+- minimal editorial tone
+
+That lets Obsrvr ship a flagship developer product that many builders can trust and compose, while Prism remains free to be highly humanized, expressive, and opinionated.

--- a/obsrvr-lake/stellar-query-api/docs/defi-openapi.yaml
+++ b/obsrvr-lake/stellar-query-api/docs/defi-openapi.yaml
@@ -1,0 +1,499 @@
+openapi: 3.0.3
+info:
+  title: Obsrvr Lake DeFi Positions API
+  version: 0.1.0
+  description: |
+    Semantic DeFi positions API for Obsrvr Lake.
+
+    Provides normalized protocol registry, market metadata, user exposure summaries,
+    current positions, and historical time-series across supported Stellar DeFi protocols.
+
+    This API is designed to sit on top of serving.sv_defi_* tables populated by a
+    dedicated DeFi position processor.
+servers:
+  - url: https://gateway.withobsrvr.com/lake/v1/testnet
+    description: Testnet (via gateway)
+  - url: http://localhost:8080
+    description: Local development
+
+tags:
+  - name: DeFi
+  - name: DeFi Registry
+  - name: DeFi Markets
+  - name: DeFi Positions
+  - name: DeFi Status
+
+paths:
+  /api/v1/semantic/defi/protocols:
+    get:
+      tags: [DeFi Registry]
+      summary: List supported DeFi protocols
+      operationId: getDefiProtocols
+      parameters:
+        - in: query
+          name: status
+          schema: { type: string, enum: [active, degraded, paused, retired] }
+        - in: query
+          name: category
+          schema: { type: string }
+        - in: query
+          name: network
+          schema: { type: string, default: testnet }
+      responses:
+        '200':
+          description: Supported protocol registry entries.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  protocols:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/DefiProtocol'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/semantic/defi/markets:
+    get:
+      tags: [DeFi Markets]
+      summary: List DeFi markets
+      operationId: getDefiMarkets
+      parameters:
+        - in: query
+          name: protocol
+          schema: { type: string }
+        - in: query
+          name: market_type
+          schema: { type: string }
+        - in: query
+          name: active_only
+          schema: { type: boolean, default: true }
+        - in: query
+          name: limit
+          schema: { type: integer, minimum: 1, maximum: 500, default: 100 }
+        - in: query
+          name: cursor
+          schema: { type: string }
+      responses:
+        '200':
+          description: Paginated list of markets.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  markets:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/DefiMarket'
+                  count:
+                    type: integer
+                  has_more:
+                    type: boolean
+                  next_cursor:
+                    type: string
+                    nullable: true
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/semantic/defi/status:
+    get:
+      tags: [DeFi Status]
+      summary: Get DeFi protocol freshness and degradation status
+      operationId: getDefiStatus
+      responses:
+        '200':
+          description: Current operational status for the DeFi layer.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DefiStatusResponse'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/semantic/defi/exposure:
+    get:
+      tags: [DeFi Positions]
+      summary: Get aggregated DeFi exposure for a user
+      operationId: getDefiExposure
+      parameters:
+        - in: query
+          name: address
+          required: true
+          schema: { type: string }
+          description: User G-address or C-address.
+        - in: query
+          name: quote
+          schema: { type: string, default: USD }
+        - in: query
+          name: protocol
+          schema: { type: string }
+      responses:
+        '200':
+          description: Aggregated exposure summary.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DefiExposureResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/semantic/defi/positions:
+    get:
+      tags: [DeFi Positions]
+      summary: List DeFi positions for a user
+      operationId: getDefiPositions
+      parameters:
+        - in: query
+          name: address
+          required: true
+          schema: { type: string }
+        - in: query
+          name: quote
+          schema: { type: string, default: USD }
+        - in: query
+          name: protocol
+          schema: { type: string }
+        - in: query
+          name: include_closed
+          schema: { type: boolean, default: false }
+        - in: query
+          name: limit
+          schema: { type: integer, minimum: 1, maximum: 500, default: 100 }
+        - in: query
+          name: cursor
+          schema: { type: string }
+      responses:
+        '200':
+          description: Paginated list of normalized positions.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DefiPositionsResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/semantic/defi/positions/{position_id}:
+    get:
+      tags: [DeFi Positions]
+      summary: Get a single DeFi position
+      operationId: getDefiPosition
+      parameters:
+        - in: path
+          name: position_id
+          required: true
+          schema: { type: string }
+        - in: query
+          name: quote
+          schema: { type: string, default: USD }
+      responses:
+        '200':
+          description: Detailed position including components.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  position:
+                    $ref: '#/components/schemas/DefiPosition'
+                  components:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/DefiPositionComponent'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/semantic/defi/positions/history:
+    get:
+      tags: [DeFi Positions]
+      summary: Get DeFi exposure history for a user
+      operationId: getDefiPositionHistory
+      parameters:
+        - in: query
+          name: address
+          required: true
+          schema: { type: string }
+        - in: query
+          name: quote
+          schema: { type: string, default: USD }
+        - in: query
+          name: from
+          required: true
+          schema: { type: string, format: date-time }
+        - in: query
+          name: to
+          required: true
+          schema: { type: string, format: date-time }
+        - in: query
+          name: interval
+          required: true
+          schema: { type: string, enum: [1h, 1d] }
+      responses:
+        '200':
+          description: Historical exposure time series.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DefiHistoryResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+components:
+  responses:
+    BadRequest:
+      description: Invalid request parameters.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    NotFound:
+      description: Requested resource was not found.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    InternalError:
+      description: Internal server error.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+
+  schemas:
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: object
+          properties:
+            code: { type: string }
+            message: { type: string }
+
+    DefiAsset:
+      type: object
+      properties:
+        asset_type: { type: string, nullable: true }
+        asset_code: { type: string, nullable: true }
+        asset_issuer: { type: string, nullable: true }
+        asset_contract_id: { type: string, nullable: true }
+        symbol: { type: string, nullable: true }
+        decimals: { type: integer, nullable: true }
+
+    DefiProtocol:
+      type: object
+      properties:
+        protocol_id: { type: string }
+        network: { type: string }
+        display_name: { type: string }
+        slug: { type: string }
+        version: { type: string, nullable: true }
+        category: { type: string }
+        status: { type: string }
+        adapter_name: { type: string }
+        pricing_model: { type: string }
+        health_model: { type: string, nullable: true }
+        supports_history: { type: boolean }
+        supports_rewards: { type: boolean }
+        supports_health_factor: { type: boolean }
+        website_url: { type: string, nullable: true }
+        docs_url: { type: string, nullable: true }
+        icon_url: { type: string, nullable: true }
+        verified: { type: boolean }
+        config_json:
+          type: object
+          additionalProperties: true
+
+    DefiMarket:
+      type: object
+      properties:
+        market_id: { type: string }
+        protocol_id: { type: string }
+        market_type: { type: string }
+        market_address: { type: string, nullable: true }
+        pool_address: { type: string, nullable: true }
+        router_address: { type: string, nullable: true }
+        oracle_contract_id: { type: string, nullable: true }
+        input_asset_1:
+          $ref: '#/components/schemas/DefiAsset'
+        input_asset_2:
+          $ref: '#/components/schemas/DefiAsset'
+        tvl_value_usd: { type: string, nullable: true }
+        total_deposit_value_usd: { type: string, nullable: true }
+        total_borrowed_value_usd: { type: string, nullable: true }
+        apr_deposit: { type: string, nullable: true }
+        apr_borrow: { type: string, nullable: true }
+        apr_rewards: { type: string, nullable: true }
+        is_active: { type: boolean }
+        metadata_json:
+          type: object
+          additionalProperties: true
+        as_of_ledger: { type: integer, format: int64 }
+        as_of_time: { type: string, format: date-time }
+
+    DefiPositionComponent:
+      type: object
+      properties:
+        component_id: { type: string }
+        component_type: { type: string }
+        asset:
+          $ref: '#/components/schemas/DefiAsset'
+        amount: { type: string, nullable: true }
+        value: { type: string, nullable: true }
+        price: { type: string, nullable: true }
+        price_source: { type: string, nullable: true }
+        metadata_json:
+          type: object
+          additionalProperties: true
+
+    DefiPosition:
+      type: object
+      properties:
+        position_id: { type: string }
+        protocol_id: { type: string }
+        protocol_version: { type: string, nullable: true }
+        position_type: { type: string }
+        status: { type: string }
+        owner_address: { type: string }
+        account_address: { type: string, nullable: true }
+        related_address: { type: string, nullable: true }
+        market_id: { type: string, nullable: true }
+        market_address: { type: string, nullable: true }
+        position_key_hash: { type: string, nullable: true }
+        underlying_asset:
+          $ref: '#/components/schemas/DefiAsset'
+        quote_currency: { type: string }
+        deposit_amount: { type: string, nullable: true }
+        borrow_amount: { type: string, nullable: true }
+        share_amount: { type: string, nullable: true }
+        claimable_reward_amount: { type: string, nullable: true }
+        deposit_value: { type: string, nullable: true }
+        borrowed_value: { type: string, nullable: true }
+        current_value: { type: string, nullable: true }
+        net_value: { type: string, nullable: true }
+        current_return_value: { type: string, nullable: true }
+        current_return_percent: { type: string, nullable: true }
+        claimable_rewards_value: { type: string, nullable: true }
+        health_factor: { type: string, nullable: true }
+        ltv: { type: string, nullable: true }
+        collateral_ratio: { type: string, nullable: true }
+        liquidation_threshold: { type: string, nullable: true }
+        risk_status: { type: string, nullable: true }
+        protocol_state_json:
+          type: object
+          additionalProperties: true
+        valuation_json:
+          type: object
+          additionalProperties: true
+        source_json:
+          type: object
+          additionalProperties: true
+        as_of_ledger: { type: integer, format: int64 }
+        as_of_time: { type: string, format: date-time }
+        last_updated_ledger: { type: integer, format: int64 }
+        last_updated_at: { type: string, format: date-time }
+
+    DefiExposureSummary:
+      type: object
+      properties:
+        total_value: { type: string }
+        total_deposit_value: { type: string }
+        total_borrowed_value: { type: string }
+        net_value: { type: string }
+        total_claimable_rewards_value: { type: string }
+        open_position_count: { type: integer }
+        protocol_count: { type: integer }
+        lowest_health_factor: { type: string, nullable: true }
+        positions_at_risk: { type: integer }
+
+    DefiExposureResponse:
+      type: object
+      properties:
+        address: { type: string }
+        quote: { type: string }
+        as_of_ledger: { type: integer, format: int64 }
+        as_of_time: { type: string, format: date-time }
+        freshness_seconds: { type: integer }
+        data_status: { type: string }
+        totals:
+          $ref: '#/components/schemas/DefiExposureSummary'
+        by_protocol:
+          type: array
+          items:
+            type: object
+            properties:
+              protocol_id: { type: string }
+              total_value: { type: string }
+              total_deposit_value: { type: string }
+              total_borrowed_value: { type: string }
+              net_value: { type: string }
+              position_count: { type: integer }
+
+    DefiPositionsResponse:
+      type: object
+      properties:
+        address: { type: string }
+        quote: { type: string }
+        as_of_ledger: { type: integer, format: int64 }
+        as_of_time: { type: string, format: date-time }
+        freshness_seconds: { type: integer }
+        data_status: { type: string }
+        summary:
+          $ref: '#/components/schemas/DefiExposureSummary'
+        positions:
+          type: array
+          items:
+            $ref: '#/components/schemas/DefiPosition'
+        has_more: { type: boolean }
+        next_cursor: { type: string, nullable: true }
+
+    DefiHistoryPoint:
+      type: object
+      properties:
+        timestamp: { type: string, format: date-time }
+        total_value: { type: string }
+        total_deposit_value: { type: string }
+        total_borrowed_value: { type: string }
+        net_value: { type: string }
+        total_claimable_rewards_value: { type: string }
+        open_position_count: { type: integer }
+
+    DefiHistoryResponse:
+      type: object
+      properties:
+        address: { type: string }
+        quote: { type: string }
+        interval: { type: string }
+        series:
+          type: array
+          items:
+            $ref: '#/components/schemas/DefiHistoryPoint'
+
+    DefiStatusResponse:
+      type: object
+      properties:
+        status: { type: string }
+        as_of_ledger: { type: integer, format: int64, nullable: true }
+        freshness_seconds: { type: integer, nullable: true }
+        protocols:
+          type: array
+          items:
+            type: object
+            properties:
+              protocol_id: { type: string }
+              status: { type: string }
+              reason: { type: string, nullable: true }
+              last_successful_ledger: { type: integer, format: int64, nullable: true }
+              last_successful_time: { type: string, format: date-time, nullable: true }
+              freshness_seconds: { type: integer, nullable: true }
+              source_divergence: { type: boolean }

--- a/obsrvr-lake/stellar-query-api/go/handlers_defi.go
+++ b/obsrvr-lake/stellar-query-api/go/handlers_defi.go
@@ -1,0 +1,557 @@
+package main
+
+import (
+	"database/sql"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gorilla/mux"
+)
+
+// DefiAsset represents a normalized DeFi asset shape.
+type DefiAsset struct {
+	AssetType       *string `json:"asset_type,omitempty"`
+	AssetCode       *string `json:"asset_code,omitempty"`
+	AssetIssuer     *string `json:"asset_issuer,omitempty"`
+	AssetContractID *string `json:"asset_contract_id,omitempty"`
+	Symbol          *string `json:"symbol,omitempty"`
+	Decimals        *int    `json:"decimals,omitempty"`
+}
+
+// DefiProtocol represents a supported DeFi protocol.
+type DefiProtocol struct {
+	ProtocolID           string         `json:"protocol_id"`
+	Network              string         `json:"network"`
+	DisplayName          string         `json:"display_name"`
+	Slug                 string         `json:"slug"`
+	Version              *string        `json:"version,omitempty"`
+	Category             string         `json:"category"`
+	Status               string         `json:"status"`
+	AdapterName          string         `json:"adapter_name"`
+	PricingModel         string         `json:"pricing_model"`
+	HealthModel          *string        `json:"health_model,omitempty"`
+	SupportsHistory      bool           `json:"supports_history"`
+	SupportsRewards      bool           `json:"supports_rewards"`
+	SupportsHealthFactor bool           `json:"supports_health_factor"`
+	WebsiteURL           *string        `json:"website_url,omitempty"`
+	DocsURL              *string        `json:"docs_url,omitempty"`
+	IconURL              *string        `json:"icon_url,omitempty"`
+	Verified             bool           `json:"verified"`
+	ConfigJSON           map[string]any `json:"config_json"`
+}
+
+type DefiMarket struct {
+	MarketID              string         `json:"market_id"`
+	ProtocolID            string         `json:"protocol_id"`
+	MarketType            string         `json:"market_type"`
+	MarketAddress         *string        `json:"market_address,omitempty"`
+	PoolAddress           *string        `json:"pool_address,omitempty"`
+	RouterAddress         *string        `json:"router_address,omitempty"`
+	OracleContractID      *string        `json:"oracle_contract_id,omitempty"`
+	InputAsset1           *DefiAsset     `json:"input_asset_1,omitempty"`
+	InputAsset2           *DefiAsset     `json:"input_asset_2,omitempty"`
+	TVLValueUSD           *string        `json:"tvl_value_usd,omitempty"`
+	TotalDepositValueUSD  *string        `json:"total_deposit_value_usd,omitempty"`
+	TotalBorrowedValueUSD *string        `json:"total_borrowed_value_usd,omitempty"`
+	APRDeposit            *string        `json:"apr_deposit,omitempty"`
+	APRBorrow             *string        `json:"apr_borrow,omitempty"`
+	APRRewards            *string        `json:"apr_rewards,omitempty"`
+	IsActive              bool           `json:"is_active"`
+	MetadataJSON          map[string]any `json:"metadata_json"`
+	AsOfLedger            int64          `json:"as_of_ledger"`
+	AsOfTime              string         `json:"as_of_time"`
+}
+
+type DefiPositionComponent struct {
+	ComponentID   string         `json:"component_id"`
+	ComponentType string         `json:"component_type"`
+	Asset         *DefiAsset     `json:"asset,omitempty"`
+	Amount        *string        `json:"amount,omitempty"`
+	Value         *string        `json:"value,omitempty"`
+	Price         *string        `json:"price,omitempty"`
+	PriceSource   *string        `json:"price_source,omitempty"`
+	MetadataJSON  map[string]any `json:"metadata_json"`
+}
+
+type DefiPosition struct {
+	PositionID            string         `json:"position_id"`
+	ProtocolID            string         `json:"protocol_id"`
+	ProtocolVersion       *string        `json:"protocol_version,omitempty"`
+	PositionType          string         `json:"position_type"`
+	Status                string         `json:"status"`
+	OwnerAddress          string         `json:"owner_address"`
+	AccountAddress        *string        `json:"account_address,omitempty"`
+	RelatedAddress        *string        `json:"related_address,omitempty"`
+	MarketID              *string        `json:"market_id,omitempty"`
+	MarketAddress         *string        `json:"market_address,omitempty"`
+	PositionKeyHash       *string        `json:"position_key_hash,omitempty"`
+	UnderlyingAsset       *DefiAsset     `json:"underlying_asset,omitempty"`
+	QuoteCurrency         string         `json:"quote_currency"`
+	DepositAmount         *string        `json:"deposit_amount,omitempty"`
+	BorrowAmount          *string        `json:"borrow_amount,omitempty"`
+	ShareAmount           *string        `json:"share_amount,omitempty"`
+	ClaimableRewardAmount *string        `json:"claimable_reward_amount,omitempty"`
+	DepositValue          *string        `json:"deposit_value,omitempty"`
+	BorrowedValue         *string        `json:"borrowed_value,omitempty"`
+	CurrentValue          *string        `json:"current_value,omitempty"`
+	NetValue              *string        `json:"net_value,omitempty"`
+	CurrentReturnValue    *string        `json:"current_return_value,omitempty"`
+	CurrentReturnPercent  *string        `json:"current_return_percent,omitempty"`
+	ClaimableRewardsValue *string        `json:"claimable_rewards_value,omitempty"`
+	HealthFactor          *string        `json:"health_factor,omitempty"`
+	LTV                   *string        `json:"ltv,omitempty"`
+	CollateralRatio       *string        `json:"collateral_ratio,omitempty"`
+	LiquidationThreshold  *string        `json:"liquidation_threshold,omitempty"`
+	RiskStatus            *string        `json:"risk_status,omitempty"`
+	ProtocolStateJSON     map[string]any `json:"protocol_state_json"`
+	ValuationJSON         map[string]any `json:"valuation_json"`
+	SourceJSON            map[string]any `json:"source_json"`
+	AsOfLedger            int64          `json:"as_of_ledger"`
+	AsOfTime              string         `json:"as_of_time"`
+	LastUpdatedLedger     int64          `json:"last_updated_ledger"`
+	LastUpdatedAt         string         `json:"last_updated_at"`
+}
+
+type DefiExposureSummary struct {
+	TotalValue                 string  `json:"total_value"`
+	TotalDepositValue          string  `json:"total_deposit_value"`
+	TotalBorrowedValue         string  `json:"total_borrowed_value"`
+	NetValue                   string  `json:"net_value"`
+	TotalClaimableRewardsValue string  `json:"total_claimable_rewards_value"`
+	OpenPositionCount          int     `json:"open_position_count"`
+	ProtocolCount              int     `json:"protocol_count"`
+	LowestHealthFactor         *string `json:"lowest_health_factor,omitempty"`
+	PositionsAtRisk            int     `json:"positions_at_risk"`
+}
+
+type DefiExposureByProtocol struct {
+	ProtocolID         string `json:"protocol_id"`
+	TotalValue         string `json:"total_value"`
+	TotalDepositValue  string `json:"total_deposit_value"`
+	TotalBorrowedValue string `json:"total_borrowed_value"`
+	NetValue           string `json:"net_value"`
+	PositionCount      int    `json:"position_count"`
+}
+
+type DefiExposureResponse struct {
+	Address          string                   `json:"address"`
+	Quote            string                   `json:"quote"`
+	AsOfLedger       int64                    `json:"as_of_ledger"`
+	AsOfTime         string                   `json:"as_of_time"`
+	FreshnessSeconds int64                    `json:"freshness_seconds"`
+	DataStatus       string                   `json:"data_status"`
+	Totals           DefiExposureSummary      `json:"totals"`
+	ByProtocol       []DefiExposureByProtocol `json:"by_protocol"`
+}
+
+type DefiPositionsResponse struct {
+	Address          string              `json:"address"`
+	Quote            string              `json:"quote"`
+	AsOfLedger       int64               `json:"as_of_ledger"`
+	AsOfTime         string              `json:"as_of_time"`
+	FreshnessSeconds int64               `json:"freshness_seconds"`
+	DataStatus       string              `json:"data_status"`
+	Summary          DefiExposureSummary `json:"summary"`
+	Positions        []DefiPosition      `json:"positions"`
+	HasMore          bool                `json:"has_more"`
+	NextCursor       *string             `json:"next_cursor"`
+}
+
+type DefiStatusProtocol struct {
+	ProtocolID           string  `json:"protocol_id"`
+	Status               string  `json:"status"`
+	Reason               *string `json:"reason,omitempty"`
+	LastSuccessfulLedger *int64  `json:"last_successful_ledger,omitempty"`
+	LastSuccessfulTime   *string `json:"last_successful_time,omitempty"`
+	FreshnessSeconds     *int    `json:"freshness_seconds,omitempty"`
+	SourceDivergence     bool    `json:"source_divergence"`
+}
+
+type DefiStatusResponse struct {
+	Status           string               `json:"status"`
+	AsOfLedger       *int64               `json:"as_of_ledger,omitempty"`
+	FreshnessSeconds *int                 `json:"freshness_seconds,omitempty"`
+	Protocols        []DefiStatusProtocol `json:"protocols"`
+}
+
+type DefiProtocolFilters struct {
+	Status   string
+	Category string
+	Network  string
+}
+
+type DefiMarketFilters struct {
+	Protocol   string
+	MarketType string
+	ActiveOnly bool
+	Limit      int
+	Cursor     *DefiCursor
+}
+
+type DefiPositionsFilters struct {
+	Address       string
+	Quote         string
+	Protocol      string
+	IncludeClosed bool
+	Limit         int
+	Cursor        *DefiCursor
+}
+
+type DefiCursor struct {
+	ID string
+}
+
+func (c DefiCursor) Encode() string {
+	return base64.StdEncoding.EncodeToString([]byte(c.ID))
+}
+
+func DecodeDefiCursor(raw string) (*DefiCursor, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	decoded, err := base64.StdEncoding.DecodeString(raw)
+	if err != nil {
+		return nil, err
+	}
+	if len(decoded) == 0 {
+		return nil, errors.New("empty cursor")
+	}
+	return &DefiCursor{ID: string(decoded)}, nil
+}
+
+func nullableString(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+func nullableInt32(v sql.NullInt32) *int {
+	if !v.Valid {
+		return nil
+	}
+	i := int(v.Int32)
+	return &i
+}
+
+func jsonObject(raw []byte) map[string]any {
+	if len(raw) == 0 {
+		return map[string]any{}
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil || out == nil {
+		return map[string]any{}
+	}
+	return out
+}
+
+func jsonByProtocol(raw []byte) []DefiExposureByProtocol {
+	if len(raw) == 0 {
+		return []DefiExposureByProtocol{}
+	}
+	var out []DefiExposureByProtocol
+	if err := json.Unmarshal(raw, &out); err != nil || out == nil {
+		return []DefiExposureByProtocol{}
+	}
+	return out
+}
+
+func buildDefiAsset(assetType, assetCode, assetIssuer, assetContractID, symbol sql.NullString, decimals sql.NullInt32) *DefiAsset {
+	if !assetType.Valid && !assetCode.Valid && !assetIssuer.Valid && !assetContractID.Valid && !symbol.Valid && !decimals.Valid {
+		return nil
+	}
+	asset := &DefiAsset{}
+	if assetType.Valid {
+		asset.AssetType = &assetType.String
+	}
+	if assetCode.Valid {
+		asset.AssetCode = &assetCode.String
+	}
+	if assetIssuer.Valid {
+		asset.AssetIssuer = &assetIssuer.String
+	}
+	if assetContractID.Valid {
+		asset.AssetContractID = &assetContractID.String
+	}
+	if symbol.Valid {
+		asset.Symbol = &symbol.String
+	}
+	asset.Decimals = nullableInt32(decimals)
+	return asset
+}
+
+func parseBoolQueryParam(r *http.Request, name string, defaultVal bool) (bool, error) {
+	v := r.URL.Query().Get(name)
+	if v == "" {
+		return defaultVal, nil
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return defaultVal, err
+	}
+	return b, nil
+}
+
+func freshnessSeconds(ts time.Time) int64 {
+	if ts.IsZero() {
+		return 0
+	}
+	sec := int64(time.Since(ts).Seconds())
+	if sec < 0 {
+		return 0
+	}
+	return sec
+}
+
+// HandleDefiProtocols serves GET /api/v1/semantic/defi/protocols
+// @Summary List supported DeFi protocols
+// @Tags DeFi Registry
+// @Produce json
+// @Param status query string false "Filter by protocol status"
+// @Param category query string false "Filter by protocol category"
+// @Param network query string false "Network name" default(testnet)
+// @Success 200 {object} map[string]interface{}
+// @Failure 500 {object} map[string]interface{}
+// @Router /api/v1/semantic/defi/protocols [get]
+func (h *SemanticHandlers) HandleDefiProtocols(w http.ResponseWriter, r *http.Request) {
+	if h.unified == nil || h.unified.hot == nil {
+		respondError(w, "defi endpoints require silver hot reader", http.StatusServiceUnavailable)
+		return
+	}
+
+	filters := DefiProtocolFilters{
+		Status:   strings.TrimSpace(r.URL.Query().Get("status")),
+		Category: strings.TrimSpace(r.URL.Query().Get("category")),
+		Network:  strings.TrimSpace(r.URL.Query().Get("network")),
+	}
+	if filters.Network == "" {
+		filters.Network = "testnet"
+	}
+
+	protocols, err := h.unified.hot.GetDefiProtocols(r.Context(), filters)
+	if err != nil {
+		respondError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	respondJSON(w, map[string]any{"protocols": protocols})
+}
+
+// HandleDefiMarkets serves GET /api/v1/semantic/defi/markets
+// @Summary List DeFi markets
+// @Tags DeFi Markets
+// @Produce json
+// @Param protocol query string false "Filter by protocol id"
+// @Param market_type query string false "Filter by market type"
+// @Param active_only query bool false "Only active markets" default(true)
+// @Param limit query int false "Max results" default(100)
+// @Param cursor query string false "Pagination cursor"
+// @Success 200 {object} map[string]interface{}
+// @Failure 400 {object} map[string]interface{}
+// @Failure 500 {object} map[string]interface{}
+// @Router /api/v1/semantic/defi/markets [get]
+func (h *SemanticHandlers) HandleDefiMarkets(w http.ResponseWriter, r *http.Request) {
+	if h.unified == nil || h.unified.hot == nil {
+		respondError(w, "defi endpoints require silver hot reader", http.StatusServiceUnavailable)
+		return
+	}
+
+	activeOnly, err := parseBoolQueryParam(r, "active_only", true)
+	if err != nil {
+		respondError(w, "invalid active_only: must be true or false", http.StatusBadRequest)
+		return
+	}
+	cursor, err := DecodeDefiCursor(r.URL.Query().Get("cursor"))
+	if err != nil {
+		respondError(w, "invalid cursor", http.StatusBadRequest)
+		return
+	}
+
+	filters := DefiMarketFilters{
+		Protocol:   strings.TrimSpace(r.URL.Query().Get("protocol")),
+		MarketType: strings.TrimSpace(r.URL.Query().Get("market_type")),
+		ActiveOnly: activeOnly,
+		Limit:      parseLimit(r, 100, 500),
+		Cursor:     cursor,
+	}
+
+	markets, nextCursor, hasMore, err := h.unified.hot.GetDefiMarkets(r.Context(), filters)
+	if err != nil {
+		respondError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	resp := map[string]any{
+		"markets":     markets,
+		"count":       len(markets),
+		"has_more":    hasMore,
+		"next_cursor": nil,
+	}
+	if nextCursor != "" {
+		resp["next_cursor"] = nextCursor
+	}
+	respondJSON(w, resp)
+}
+
+// HandleDefiStatus serves GET /api/v1/semantic/defi/status
+// @Summary Get DeFi protocol freshness and degradation status
+// @Tags DeFi Status
+// @Produce json
+// @Success 200 {object} DefiStatusResponse
+// @Failure 500 {object} map[string]interface{}
+// @Router /api/v1/semantic/defi/status [get]
+func (h *SemanticHandlers) HandleDefiStatus(w http.ResponseWriter, r *http.Request) {
+	if h.unified == nil || h.unified.hot == nil {
+		respondError(w, "defi endpoints require silver hot reader", http.StatusServiceUnavailable)
+		return
+	}
+
+	status, err := h.unified.hot.GetDefiStatus(r.Context())
+	if err != nil {
+		respondError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	respondJSON(w, status)
+}
+
+// HandleDefiExposure serves GET /api/v1/semantic/defi/exposure
+// @Summary Get aggregated DeFi exposure for a user
+// @Tags DeFi Positions
+// @Produce json
+// @Param address query string true "User address"
+// @Param quote query string false "Quote currency" default(USD)
+// @Param protocol query string false "Optional protocol filter"
+// @Success 200 {object} DefiExposureResponse
+// @Failure 400 {object} map[string]interface{}
+// @Failure 404 {object} map[string]interface{}
+// @Failure 500 {object} map[string]interface{}
+// @Router /api/v1/semantic/defi/exposure [get]
+func (h *SemanticHandlers) HandleDefiExposure(w http.ResponseWriter, r *http.Request) {
+	if h.unified == nil || h.unified.hot == nil {
+		respondError(w, "defi endpoints require silver hot reader", http.StatusServiceUnavailable)
+		return
+	}
+
+	address := strings.TrimSpace(r.URL.Query().Get("address"))
+	if address == "" {
+		respondError(w, "address parameter is required", http.StatusBadRequest)
+		return
+	}
+	quote := strings.TrimSpace(r.URL.Query().Get("quote"))
+	if quote == "" {
+		quote = "USD"
+	}
+
+	resp, err := h.unified.hot.GetDefiExposure(r.Context(), address, quote, strings.TrimSpace(r.URL.Query().Get("protocol")))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			respondError(w, "defi exposure not found", http.StatusNotFound)
+			return
+		}
+		respondError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	respondJSON(w, resp)
+}
+
+// HandleDefiPositions serves GET /api/v1/semantic/defi/positions
+// @Summary List DeFi positions for a user
+// @Tags DeFi Positions
+// @Produce json
+// @Param address query string true "User address"
+// @Param quote query string false "Quote currency" default(USD)
+// @Param protocol query string false "Optional protocol filter"
+// @Param include_closed query bool false "Include closed positions" default(false)
+// @Param limit query int false "Max results" default(100)
+// @Param cursor query string false "Pagination cursor"
+// @Success 200 {object} DefiPositionsResponse
+// @Failure 400 {object} map[string]interface{}
+// @Failure 500 {object} map[string]interface{}
+// @Router /api/v1/semantic/defi/positions [get]
+func (h *SemanticHandlers) HandleDefiPositions(w http.ResponseWriter, r *http.Request) {
+	if h.unified == nil || h.unified.hot == nil {
+		respondError(w, "defi endpoints require silver hot reader", http.StatusServiceUnavailable)
+		return
+	}
+
+	address := strings.TrimSpace(r.URL.Query().Get("address"))
+	if address == "" {
+		respondError(w, "address parameter is required", http.StatusBadRequest)
+		return
+	}
+	includeClosed, err := parseBoolQueryParam(r, "include_closed", false)
+	if err != nil {
+		respondError(w, "invalid include_closed: must be true or false", http.StatusBadRequest)
+		return
+	}
+	cursor, err := DecodeDefiCursor(r.URL.Query().Get("cursor"))
+	if err != nil {
+		respondError(w, "invalid cursor", http.StatusBadRequest)
+		return
+	}
+	quote := strings.TrimSpace(r.URL.Query().Get("quote"))
+	if quote == "" {
+		quote = "USD"
+	}
+
+	resp, err := h.unified.hot.GetDefiPositions(r.Context(), DefiPositionsFilters{
+		Address:       address,
+		Quote:         quote,
+		Protocol:      strings.TrimSpace(r.URL.Query().Get("protocol")),
+		IncludeClosed: includeClosed,
+		Limit:         parseLimit(r, 100, 500),
+		Cursor:        cursor,
+	})
+	if err != nil {
+		respondError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	respondJSON(w, resp)
+}
+
+// HandleDefiPosition serves GET /api/v1/semantic/defi/positions/{position_id}
+// @Summary Get a single DeFi position
+// @Tags DeFi Positions
+// @Produce json
+// @Param position_id path string true "Position ID"
+// @Param quote query string false "Quote currency" default(USD)
+// @Success 200 {object} map[string]interface{}
+// @Failure 404 {object} map[string]interface{}
+// @Failure 500 {object} map[string]interface{}
+// @Router /api/v1/semantic/defi/positions/{position_id} [get]
+func (h *SemanticHandlers) HandleDefiPosition(w http.ResponseWriter, r *http.Request) {
+	if h.unified == nil || h.unified.hot == nil {
+		respondError(w, "defi endpoints require silver hot reader", http.StatusServiceUnavailable)
+		return
+	}
+
+	positionID := mux.Vars(r)["position_id"]
+	if strings.TrimSpace(positionID) == "" {
+		respondError(w, "position_id required", http.StatusBadRequest)
+		return
+	}
+	quote := strings.TrimSpace(r.URL.Query().Get("quote"))
+	if quote == "" {
+		quote = "USD"
+	}
+
+	position, components, err := h.unified.hot.GetDefiPosition(r.Context(), positionID, quote)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			respondError(w, "position not found", http.StatusNotFound)
+			return
+		}
+		respondError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	respondJSON(w, map[string]any{
+		"position":   position,
+		"components": components,
+	})
+}

--- a/obsrvr-lake/stellar-query-api/go/handlers_defi_test.go
+++ b/obsrvr-lake/stellar-query-api/go/handlers_defi_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestDecodeDefiCursor(t *testing.T) {
+	cursor, err := DecodeDefiCursor((DefiCursor{ID: "market-123"}).Encode())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cursor == nil || cursor.ID != "market-123" {
+		t.Fatalf("unexpected cursor: %#v", cursor)
+	}
+}
+
+func TestDecodeDefiCursorInvalid(t *testing.T) {
+	if _, err := DecodeDefiCursor("not-base64"); err == nil {
+		t.Fatal("expected error for invalid cursor")
+	}
+}
+
+func TestHandleDefiExposureRequiresAddress(t *testing.T) {
+	h := &SemanticHandlers{}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/semantic/defi/exposure", nil)
+	w := httptest.NewRecorder()
+
+	h.HandleDefiExposure(w, req)
+
+	if w.Code != http.StatusServiceUnavailable && w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 503 or 400, got %d", w.Code)
+	}
+}
+
+func TestHandleDefiPositionsRequiresAddress(t *testing.T) {
+	h := &SemanticHandlers{unified: &UnifiedSilverReader{hot: &SilverHotReader{}}}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/semantic/defi/positions", nil)
+	w := httptest.NewRecorder()
+
+	h.HandleDefiPositions(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandleDefiMarketsRejectsInvalidBool(t *testing.T) {
+	h := &SemanticHandlers{unified: &UnifiedSilverReader{hot: &SilverHotReader{}}}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/semantic/defi/markets?active_only=maybe", nil)
+	w := httptest.NewRecorder()
+
+	h.HandleDefiMarkets(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}

--- a/obsrvr-lake/stellar-query-api/go/handlers_tx_receipt.go
+++ b/obsrvr-lake/stellar-query-api/go/handlers_tx_receipt.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/lib/pq"
+)
+
+// TxReceiptHandlers serves GET /api/v1/silver/tx/{hash}/receipt.
+//
+// Single-lookup alternative to Prism's existing per-page pattern of hitting
+// /full + /semantic + /effects + /diffs + /events in parallel (observed
+// P95 ~5s bounded by /diffs). This endpoint does one indexed PK read against
+// serving.sv_tx_receipts and returns the pre-materialized wide JSON row.
+//
+// Response shape is a thin envelope around the projected columns — most of
+// the weight is in the JSONB fields (full_json, semantic_json, effects_json,
+// diffs_json, events_json). Prism consumes the ones it needs per page section.
+//
+// If the row is missing (row not yet projected / tx too recent / projector
+// offline), returns 404 so the frontend can fall back to the classic
+// per-section endpoints.
+type TxReceiptHandlers struct {
+	// Uses the SilverHotReader's PG handle — serving tables live in silver_hot
+	// alongside public.* per the existing architecture.
+	hotReader *SilverHotReader
+}
+
+func NewTxReceiptHandlers(hotReader *SilverHotReader) *TxReceiptHandlers {
+	return &TxReceiptHandlers{hotReader: hotReader}
+}
+
+type TxReceiptResponse struct {
+	TxHash             string          `json:"tx_hash"`
+	LedgerSequence     int64           `json:"ledger_sequence"`
+	CreatedAt          string          `json:"created_at"`
+	SourceAccount      *string         `json:"source_account,omitempty"`
+	Successful         bool            `json:"successful"`
+	OperationCount     *int            `json:"operation_count,omitempty"`
+	TxType             *string         `json:"tx_type,omitempty"`
+	PrimaryContractID  *string         `json:"primary_contract_id,omitempty"`
+	InvolvedContracts  []string        `json:"involved_contracts,omitempty"`
+	InvolvedAccounts   []string        `json:"involved_accounts,omitempty"`
+
+	// Raw JSONB sections — callers pick whichever they need.
+	Full               json.RawMessage `json:"full,omitempty"`
+	Semantic           json.RawMessage `json:"semantic,omitempty"`
+	Effects            json.RawMessage `json:"effects,omitempty"`
+	Diffs              json.RawMessage `json:"diffs,omitempty"`
+	Events             json.RawMessage `json:"events,omitempty"`
+
+	MaterializedAt     string          `json:"materialized_at"`
+	SourceVersion      string          `json:"source_version"`
+}
+
+// HandleTxReceipt serves GET /api/v1/silver/tx/{hash}/receipt.
+func (h *TxReceiptHandlers) HandleTxReceipt(w http.ResponseWriter, r *http.Request) {
+	if h == nil || h.hotReader == nil || h.hotReader.db == nil {
+		respondError(w, "silver hot reader unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	vars := mux.Vars(r)
+	txHash := vars["hash"]
+	if txHash == "" {
+		respondError(w, "tx hash required", http.StatusBadRequest)
+		return
+	}
+
+	const q = `
+		SELECT tx_hash, ledger_sequence, created_at, source_account, successful,
+		       operation_count, tx_type, primary_contract_id,
+		       involved_contracts, involved_accounts,
+		       full_json, semantic_json, effects_json, diffs_json, events_json,
+		       materialized_at, source_version
+		  FROM serving.sv_tx_receipts
+		 WHERE tx_hash = $1
+	`
+	var (
+		resp              TxReceiptResponse
+		createdAt         sql.NullString
+		sourceAccount     sql.NullString
+		opCount           sql.NullInt64
+		txType            sql.NullString
+		primaryContract   sql.NullString
+		involvedContracts []string
+		involvedAccounts  []string
+		fullJSON          []byte
+		semanticJSON      []byte
+		effectsJSON       []byte
+		diffsJSON         []byte
+		eventsJSON        []byte
+		materializedAt    sql.NullString
+	)
+
+	err := h.hotReader.db.QueryRowContext(r.Context(), q, txHash).Scan(
+		&resp.TxHash, &resp.LedgerSequence, &createdAt, &sourceAccount, &resp.Successful,
+		&opCount, &txType, &primaryContract,
+		pq.Array(&involvedContracts), pq.Array(&involvedAccounts),
+		&fullJSON, &semanticJSON, &effectsJSON, &diffsJSON, &eventsJSON,
+		&materializedAt, &resp.SourceVersion,
+	)
+	if err == sql.ErrNoRows {
+		respondError(w, "receipt not yet materialized for tx "+txHash, http.StatusNotFound)
+		return
+	}
+	if err != nil {
+		respondError(w, "tx receipt query failed: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if createdAt.Valid {
+		resp.CreatedAt = createdAt.String
+	}
+	if sourceAccount.Valid {
+		s := sourceAccount.String
+		resp.SourceAccount = &s
+	}
+	if opCount.Valid {
+		v := int(opCount.Int64)
+		resp.OperationCount = &v
+	}
+	if txType.Valid {
+		s := txType.String
+		resp.TxType = &s
+	}
+	if primaryContract.Valid {
+		s := primaryContract.String
+		resp.PrimaryContractID = &s
+	}
+	resp.InvolvedContracts = involvedContracts
+	resp.InvolvedAccounts = involvedAccounts
+	if len(fullJSON) > 0 {
+		resp.Full = fullJSON
+	}
+	if len(semanticJSON) > 0 {
+		resp.Semantic = semanticJSON
+	}
+	if len(effectsJSON) > 0 {
+		resp.Effects = effectsJSON
+	}
+	if len(diffsJSON) > 0 {
+		resp.Diffs = diffsJSON
+	}
+	if len(eventsJSON) > 0 {
+		resp.Events = eventsJSON
+	}
+	if materializedAt.Valid {
+		resp.MaterializedAt = materializedAt.String
+	}
+
+	respondJSON(w, resp)
+}
+

--- a/obsrvr-lake/stellar-query-api/go/routes_decode_gold_semantic.go
+++ b/obsrvr-lake/stellar-query-api/go/routes_decode_gold_semantic.go
@@ -34,6 +34,13 @@ func (app *application) registerTokenAndDecodeRoutes(router *mux.Router) {
 	router.HandleFunc("/api/v1/silver/tx/{hash}/full", decodeHandlers.HandleFullTransaction).Methods("GET")
 	router.HandleFunc("/api/v1/silver/contracts/{id}/interface", decodeHandlers.HandleContractInterface).Methods("GET")
 	router.HandleFunc("/api/v1/silver/decode/scval", decodeHandlers.HandleDecodeScVal).Methods("POST")
+
+	// Prism tx-detail page fast path: single PK lookup into serving.sv_tx_receipts
+	// instead of 5–7 parallel cold-Parquet queries. Returns 404 if the row hasn't
+	// been materialized yet; frontend should fall back to the per-section endpoints
+	// above when that happens.
+	txReceiptHandlers := NewTxReceiptHandlers(silverHotReader)
+	router.HandleFunc("/api/v1/silver/tx/{hash}/receipt", txReceiptHandlers.HandleTxReceipt).Methods("GET")
 }
 
 func (app *application) registerGoldRoutes(router *mux.Router) {
@@ -71,4 +78,10 @@ func (app *application) registerSemanticRoutes(router *mux.Router) {
 	router.HandleFunc("/api/v1/semantic/dex/pairs", semanticHandlers.HandleSemanticDexPairs).Methods("GET")
 	router.HandleFunc("/api/v1/semantic/accounts/summary", semanticHandlers.HandleSemanticAccountSummary).Methods("GET")
 	router.HandleFunc("/api/v1/semantic/tokens/{contract_id}", semanticHandlers.HandleSemanticTokenSummary).Methods("GET")
+	router.HandleFunc("/api/v1/semantic/defi/protocols", semanticHandlers.HandleDefiProtocols).Methods("GET")
+	router.HandleFunc("/api/v1/semantic/defi/markets", semanticHandlers.HandleDefiMarkets).Methods("GET")
+	router.HandleFunc("/api/v1/semantic/defi/status", semanticHandlers.HandleDefiStatus).Methods("GET")
+	router.HandleFunc("/api/v1/semantic/defi/exposure", semanticHandlers.HandleDefiExposure).Methods("GET")
+	router.HandleFunc("/api/v1/semantic/defi/positions", semanticHandlers.HandleDefiPositions).Methods("GET")
+	router.HandleFunc("/api/v1/semantic/defi/positions/{position_id}", semanticHandlers.HandleDefiPosition).Methods("GET")
 }

--- a/obsrvr-lake/stellar-query-api/go/silver_hot_reader_defi.go
+++ b/obsrvr-lake/stellar-query-api/go/silver_hot_reader_defi.go
@@ -1,0 +1,628 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+)
+
+func (h *SilverHotReader) GetDefiProtocols(ctx context.Context, filters DefiProtocolFilters) ([]DefiProtocol, error) {
+	query := `SELECT protocol_id, network, display_name, slug, version, category, status,
+		adapter_name, pricing_model, health_model,
+		supports_history, supports_rewards, supports_health_factor,
+		website_url, docs_url, icon_url, verified, config_json
+		FROM serving.sv_defi_protocols WHERE 1=1`
+	args := []any{}
+	argIdx := 1
+
+	if filters.Status != "" {
+		query += fmt.Sprintf(" AND status = $%d", argIdx)
+		args = append(args, filters.Status)
+		argIdx++
+	}
+	if filters.Category != "" {
+		query += fmt.Sprintf(" AND category = $%d", argIdx)
+		args = append(args, filters.Category)
+		argIdx++
+	}
+	if filters.Network != "" {
+		query += fmt.Sprintf(" AND network = $%d", argIdx)
+		args = append(args, filters.Network)
+		argIdx++
+	}
+
+	query += " ORDER BY display_name ASC"
+	rows, err := h.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	results := []DefiProtocol{}
+	for rows.Next() {
+		var p DefiProtocol
+		var version, healthModel, websiteURL, docsURL, iconURL sql.NullString
+		var configRaw []byte
+		if err := rows.Scan(
+			&p.ProtocolID, &p.Network, &p.DisplayName, &p.Slug, &version, &p.Category, &p.Status,
+			&p.AdapterName, &p.PricingModel, &healthModel,
+			&p.SupportsHistory, &p.SupportsRewards, &p.SupportsHealthFactor,
+			&websiteURL, &docsURL, &iconURL, &p.Verified, &configRaw,
+		); err != nil {
+			return nil, err
+		}
+		if version.Valid {
+			p.Version = &version.String
+		}
+		if healthModel.Valid {
+			p.HealthModel = &healthModel.String
+		}
+		if websiteURL.Valid {
+			p.WebsiteURL = &websiteURL.String
+		}
+		if docsURL.Valid {
+			p.DocsURL = &docsURL.String
+		}
+		if iconURL.Valid {
+			p.IconURL = &iconURL.String
+		}
+		p.ConfigJSON = jsonObject(configRaw)
+		results = append(results, p)
+	}
+	return results, rows.Err()
+}
+
+func (h *SilverHotReader) GetDefiMarkets(ctx context.Context, filters DefiMarketFilters) ([]DefiMarket, string, bool, error) {
+	requestLimit := filters.Limit + 1
+	query := `SELECT market_id, protocol_id, market_type, market_address, pool_address, router_address,
+		oracle_contract_id,
+		input_asset_1_type, input_asset_1_code, input_asset_1_issuer, input_asset_1_contract_id, input_asset_1_symbol, input_asset_1_decimals,
+		input_asset_2_type, input_asset_2_code, input_asset_2_issuer, input_asset_2_contract_id, input_asset_2_symbol, input_asset_2_decimals,
+		tvl_value_usd::TEXT, total_deposit_value_usd::TEXT, total_borrowed_value_usd::TEXT,
+		apr_deposit::TEXT, apr_borrow::TEXT, apr_rewards::TEXT,
+		is_active, metadata_json, as_of_ledger, as_of_time
+		FROM serving.sv_defi_markets_current WHERE 1=1`
+	args := []any{}
+	argIdx := 1
+
+	if filters.Protocol != "" {
+		query += fmt.Sprintf(" AND protocol_id = $%d", argIdx)
+		args = append(args, filters.Protocol)
+		argIdx++
+	}
+	if filters.MarketType != "" {
+		query += fmt.Sprintf(" AND market_type = $%d", argIdx)
+		args = append(args, filters.MarketType)
+		argIdx++
+	}
+	if filters.ActiveOnly {
+		query += " AND is_active = true"
+	}
+	if filters.Cursor != nil {
+		query += fmt.Sprintf(" AND market_id > $%d", argIdx)
+		args = append(args, filters.Cursor.ID)
+		argIdx++
+	}
+
+	query += fmt.Sprintf(" ORDER BY market_id ASC LIMIT $%d", argIdx)
+	args = append(args, requestLimit)
+
+	rows, err := h.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, "", false, err
+	}
+	defer rows.Close()
+
+	results := []DefiMarket{}
+	for rows.Next() {
+		var m DefiMarket
+		var marketAddress, poolAddress, routerAddress, oracleContractID sql.NullString
+		var a1Type, a1Code, a1Issuer, a1ContractID, a1Symbol sql.NullString
+		var a2Type, a2Code, a2Issuer, a2ContractID, a2Symbol sql.NullString
+		var a1Decimals, a2Decimals sql.NullInt32
+		var tvl, totalDeposit, totalBorrowed, aprDeposit, aprBorrow, aprRewards sql.NullString
+		var metadataRaw []byte
+		var asOfTime time.Time
+		if err := rows.Scan(
+			&m.MarketID, &m.ProtocolID, &m.MarketType, &marketAddress, &poolAddress, &routerAddress,
+			&oracleContractID,
+			&a1Type, &a1Code, &a1Issuer, &a1ContractID, &a1Symbol, &a1Decimals,
+			&a2Type, &a2Code, &a2Issuer, &a2ContractID, &a2Symbol, &a2Decimals,
+			&tvl, &totalDeposit, &totalBorrowed,
+			&aprDeposit, &aprBorrow, &aprRewards,
+			&m.IsActive, &metadataRaw, &m.AsOfLedger, &asOfTime,
+		); err != nil {
+			return nil, "", false, err
+		}
+		m.MarketAddress = nullableString(marketAddress.String)
+		m.PoolAddress = nullableString(poolAddress.String)
+		m.RouterAddress = nullableString(routerAddress.String)
+		m.OracleContractID = nullableString(oracleContractID.String)
+		m.InputAsset1 = buildDefiAsset(a1Type, a1Code, a1Issuer, a1ContractID, a1Symbol, a1Decimals)
+		m.InputAsset2 = buildDefiAsset(a2Type, a2Code, a2Issuer, a2ContractID, a2Symbol, a2Decimals)
+		m.TVLValueUSD = nullableString(tvl.String)
+		m.TotalDepositValueUSD = nullableString(totalDeposit.String)
+		m.TotalBorrowedValueUSD = nullableString(totalBorrowed.String)
+		m.APRDeposit = nullableString(aprDeposit.String)
+		m.APRBorrow = nullableString(aprBorrow.String)
+		m.APRRewards = nullableString(aprRewards.String)
+		m.MetadataJSON = jsonObject(metadataRaw)
+		m.AsOfTime = asOfTime.UTC().Format(time.RFC3339)
+		results = append(results, m)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, "", false, err
+	}
+
+	hasMore := len(results) > filters.Limit
+	if hasMore {
+		results = results[:filters.Limit]
+	}
+	var nextCursor string
+	if hasMore && len(results) > 0 {
+		nextCursor = (DefiCursor{ID: results[len(results)-1].MarketID}).Encode()
+	}
+	return results, nextCursor, hasMore, nil
+}
+
+func (h *SilverHotReader) GetDefiStatus(ctx context.Context) (*DefiStatusResponse, error) {
+	rows, err := h.db.QueryContext(ctx, `
+		SELECT p.protocol_id,
+			COALESCE(s.status, CASE WHEN p.status IN ('active', 'degraded') THEN 'ok' ELSE p.status END) as api_status,
+			s.reason,
+			s.last_successful_ledger,
+			s.last_successful_time,
+			s.freshness_seconds,
+			COALESCE(s.source_divergence, false)
+		FROM serving.sv_defi_protocols p
+		LEFT JOIN serving.sv_defi_protocol_status s ON s.protocol_id = p.protocol_id
+		ORDER BY p.protocol_id ASC
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	resp := &DefiStatusResponse{Status: "ok", Protocols: []DefiStatusProtocol{}}
+	var maxLedger sql.NullInt64
+	var maxFreshness sql.NullInt32
+
+	for rows.Next() {
+		var p DefiStatusProtocol
+		var reason sql.NullString
+		var lastLedger sql.NullInt64
+		var lastTime sql.NullTime
+		var fresh sql.NullInt32
+		if err := rows.Scan(&p.ProtocolID, &p.Status, &reason, &lastLedger, &lastTime, &fresh, &p.SourceDivergence); err != nil {
+			return nil, err
+		}
+		if reason.Valid {
+			p.Reason = &reason.String
+		}
+		if lastLedger.Valid {
+			v := lastLedger.Int64
+			p.LastSuccessfulLedger = &v
+			if !maxLedger.Valid || v > maxLedger.Int64 {
+				maxLedger = lastLedger
+			}
+		}
+		if lastTime.Valid {
+			formatted := lastTime.Time.UTC().Format(time.RFC3339)
+			p.LastSuccessfulTime = &formatted
+		}
+		if fresh.Valid {
+			v := int(fresh.Int32)
+			p.FreshnessSeconds = &v
+			if !maxFreshness.Valid || fresh.Int32 > maxFreshness.Int32 {
+				maxFreshness = fresh
+			}
+		}
+		resp.Status = aggregateDefiOverallStatus(resp.Status, p.Status)
+		resp.Protocols = append(resp.Protocols, p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if maxLedger.Valid {
+		v := maxLedger.Int64
+		resp.AsOfLedger = &v
+	}
+	if maxFreshness.Valid {
+		v := int(maxFreshness.Int32)
+		resp.FreshnessSeconds = &v
+	}
+	return resp, nil
+}
+
+func aggregateDefiOverallStatus(current, candidate string) string {
+	rank := func(v string) int {
+		switch strings.ToLower(v) {
+		case "halted", "paused", "retired":
+			return 4
+		case "degraded", "backfill":
+			return 3
+		case "stale_prices", "partial_protocol_coverage", "backfill_in_progress", "protocol_unavailable":
+			return 2
+		case "ok", "active":
+			return 1
+		default:
+			return 1
+		}
+	}
+	if rank(candidate) > rank(current) {
+		return candidate
+	}
+	return current
+}
+
+func (h *SilverHotReader) GetDefiExposure(ctx context.Context, address, quote, protocol string) (*DefiExposureResponse, error) {
+	if protocol != "" {
+		return h.getDefiExposureFromPositions(ctx, address, quote, protocol)
+	}
+
+	var resp DefiExposureResponse
+	var byProtocolRaw []byte
+	var asOfTime time.Time
+	var dataStatus sql.NullString
+	var lowestHealth sql.NullString
+	row := h.db.QueryRowContext(ctx, `
+		SELECT owner_address, quote_currency, as_of_ledger, as_of_time,
+			COALESCE(source_json->>'data_status', 'ok') as data_status,
+			COALESCE(total_value, 0)::TEXT,
+			COALESCE(total_deposit_value, 0)::TEXT,
+			COALESCE(total_borrowed_value, 0)::TEXT,
+			COALESCE(net_value, 0)::TEXT,
+			COALESCE(total_claimable_rewards_value, 0)::TEXT,
+			open_position_count,
+			protocol_count,
+			lowest_health_factor::TEXT,
+			positions_at_risk,
+			by_protocol_json
+		FROM serving.sv_defi_user_totals_current
+		WHERE owner_address = $1 AND quote_currency = $2
+	`, address, quote)
+	if err := row.Scan(
+		&resp.Address, &resp.Quote, &resp.AsOfLedger, &asOfTime,
+		&dataStatus,
+		&resp.Totals.TotalValue,
+		&resp.Totals.TotalDepositValue,
+		&resp.Totals.TotalBorrowedValue,
+		&resp.Totals.NetValue,
+		&resp.Totals.TotalClaimableRewardsValue,
+		&resp.Totals.OpenPositionCount,
+		&resp.Totals.ProtocolCount,
+		&lowestHealth,
+		&resp.Totals.PositionsAtRisk,
+		&byProtocolRaw,
+	); err != nil {
+		return nil, err
+	}
+	if dataStatus.Valid {
+		resp.DataStatus = dataStatus.String
+	} else {
+		resp.DataStatus = "ok"
+	}
+	if lowestHealth.Valid {
+		resp.Totals.LowestHealthFactor = &lowestHealth.String
+	}
+	resp.AsOfTime = asOfTime.UTC().Format(time.RFC3339)
+	resp.FreshnessSeconds = freshnessSeconds(asOfTime)
+	resp.ByProtocol = jsonByProtocol(byProtocolRaw)
+	return &resp, nil
+}
+
+func (h *SilverHotReader) getDefiExposureFromPositions(ctx context.Context, address, quote, protocol string) (*DefiExposureResponse, error) {
+	row := h.db.QueryRowContext(ctx, `
+		SELECT owner_address,
+			quote_currency,
+			COALESCE(MAX(as_of_ledger), 0),
+			MAX(as_of_time),
+			COALESCE(SUM(current_value), 0)::TEXT,
+			COALESCE(SUM(deposit_value), 0)::TEXT,
+			COALESCE(SUM(borrowed_value), 0)::TEXT,
+			COALESCE(SUM(net_value), 0)::TEXT,
+			COALESCE(SUM(claimable_rewards_value), 0)::TEXT,
+			COUNT(*) FILTER (WHERE status = 'open'),
+			COUNT(DISTINCT protocol_id),
+			MIN(health_factor)::TEXT,
+			COUNT(*) FILTER (WHERE risk_status IS NOT NULL AND risk_status NOT IN ('ok', 'healthy'))
+		FROM serving.sv_defi_positions_current
+		WHERE owner_address = $1 AND quote_currency = $2 AND protocol_id = $3
+		GROUP BY owner_address, quote_currency
+	`, address, quote, protocol)
+
+	var resp DefiExposureResponse
+	var asOfTime time.Time
+	var lowestHealth sql.NullString
+	if err := row.Scan(
+		&resp.Address, &resp.Quote, &resp.AsOfLedger, &asOfTime,
+		&resp.Totals.TotalValue, &resp.Totals.TotalDepositValue,
+		&resp.Totals.TotalBorrowedValue, &resp.Totals.NetValue,
+		&resp.Totals.TotalClaimableRewardsValue, &resp.Totals.OpenPositionCount,
+		&resp.Totals.ProtocolCount, &lowestHealth, &resp.Totals.PositionsAtRisk,
+	); err != nil {
+		return nil, err
+	}
+	if lowestHealth.Valid {
+		resp.Totals.LowestHealthFactor = &lowestHealth.String
+	}
+	resp.DataStatus = "ok"
+	resp.AsOfTime = asOfTime.UTC().Format(time.RFC3339)
+	resp.FreshnessSeconds = freshnessSeconds(asOfTime)
+	resp.ByProtocol = []DefiExposureByProtocol{{
+		ProtocolID:         protocol,
+		TotalValue:         resp.Totals.TotalValue,
+		TotalDepositValue:  resp.Totals.TotalDepositValue,
+		TotalBorrowedValue: resp.Totals.TotalBorrowedValue,
+		NetValue:           resp.Totals.NetValue,
+		PositionCount:      resp.Totals.OpenPositionCount,
+	}}
+	return &resp, nil
+}
+
+func (h *SilverHotReader) GetDefiPositions(ctx context.Context, filters DefiPositionsFilters) (*DefiPositionsResponse, error) {
+	summary, err := h.GetDefiExposure(ctx, filters.Address, filters.Quote, filters.Protocol)
+	if err != nil && err != sql.ErrNoRows {
+		return nil, err
+	}
+	if err == sql.ErrNoRows {
+		summary = &DefiExposureResponse{
+			Address:    filters.Address,
+			Quote:      filters.Quote,
+			DataStatus: "ok",
+			ByProtocol: []DefiExposureByProtocol{},
+			Totals: DefiExposureSummary{
+				TotalValue:                 "0",
+				TotalDepositValue:          "0",
+				TotalBorrowedValue:         "0",
+				NetValue:                   "0",
+				TotalClaimableRewardsValue: "0",
+			},
+		}
+	}
+
+	requestLimit := filters.Limit + 1
+	query := `SELECT position_id, protocol_id, protocol_version, position_type, status,
+		owner_address, account_address, related_address, market_id, market_address, position_key_hash,
+		underlying_asset_type, underlying_asset_code, underlying_asset_issuer, underlying_asset_contract_id, underlying_symbol, underlying_decimals,
+		quote_currency,
+		deposit_amount::TEXT, borrow_amount::TEXT, share_amount::TEXT, claimable_reward_amount::TEXT,
+		deposit_value::TEXT, borrowed_value::TEXT, current_value::TEXT, net_value::TEXT,
+		current_return_value::TEXT, current_return_percent::TEXT, claimable_rewards_value::TEXT,
+		health_factor::TEXT, ltv::TEXT, collateral_ratio::TEXT, liquidation_threshold::TEXT, risk_status,
+		protocol_state_json, valuation_json, source_json,
+		as_of_ledger, as_of_time, last_updated_ledger, last_updated_at
+		FROM serving.sv_defi_positions_current
+		WHERE owner_address = $1 AND quote_currency = $2`
+	args := []any{filters.Address, filters.Quote}
+	argIdx := 3
+	if filters.Protocol != "" {
+		query += fmt.Sprintf(" AND protocol_id = $%d", argIdx)
+		args = append(args, filters.Protocol)
+		argIdx++
+	}
+	if !filters.IncludeClosed {
+		query += " AND status = 'open'"
+	}
+	if filters.Cursor != nil {
+		query += fmt.Sprintf(" AND position_id > $%d", argIdx)
+		args = append(args, filters.Cursor.ID)
+		argIdx++
+	}
+	query += fmt.Sprintf(" ORDER BY position_id ASC LIMIT $%d", argIdx)
+	args = append(args, requestLimit)
+
+	rows, err := h.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	positions := []DefiPosition{}
+	for rows.Next() {
+		position, err := scanDefiPositionRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		positions = append(positions, position)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	hasMore := len(positions) > filters.Limit
+	if hasMore {
+		positions = positions[:filters.Limit]
+	}
+	var nextCursor *string
+	if hasMore && len(positions) > 0 {
+		encoded := (DefiCursor{ID: positions[len(positions)-1].PositionID}).Encode()
+		nextCursor = &encoded
+	}
+
+	resp := &DefiPositionsResponse{
+		Address:          filters.Address,
+		Quote:            filters.Quote,
+		AsOfLedger:       summary.AsOfLedger,
+		AsOfTime:         summary.AsOfTime,
+		FreshnessSeconds: summary.FreshnessSeconds,
+		DataStatus:       summary.DataStatus,
+		Summary:          summary.Totals,
+		Positions:        positions,
+		HasMore:          hasMore,
+		NextCursor:       nextCursor,
+	}
+	return resp, nil
+}
+
+func (h *SilverHotReader) GetDefiPosition(ctx context.Context, positionID, quote string) (*DefiPosition, []DefiPositionComponent, error) {
+	row := h.db.QueryRowContext(ctx, `SELECT position_id, protocol_id, protocol_version, position_type, status,
+		owner_address, account_address, related_address, market_id, market_address, position_key_hash,
+		underlying_asset_type, underlying_asset_code, underlying_asset_issuer, underlying_asset_contract_id, underlying_symbol, underlying_decimals,
+		quote_currency,
+		deposit_amount::TEXT, borrow_amount::TEXT, share_amount::TEXT, claimable_reward_amount::TEXT,
+		deposit_value::TEXT, borrowed_value::TEXT, current_value::TEXT, net_value::TEXT,
+		current_return_value::TEXT, current_return_percent::TEXT, claimable_rewards_value::TEXT,
+		health_factor::TEXT, ltv::TEXT, collateral_ratio::TEXT, liquidation_threshold::TEXT, risk_status,
+		protocol_state_json, valuation_json, source_json,
+		as_of_ledger, as_of_time, last_updated_ledger, last_updated_at
+		FROM serving.sv_defi_positions_current
+		WHERE position_id = $1 AND quote_currency = $2`, positionID, quote)
+	position, err := scanDefiPositionSingleRow(row)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	rows, err := h.db.QueryContext(ctx, `SELECT component_id, component_type,
+		asset_type, asset_code, asset_issuer, asset_contract_id, symbol, decimals,
+		amount::TEXT, value::TEXT, price::TEXT, price_source, metadata_json
+		FROM serving.sv_defi_position_components_current
+		WHERE position_id = $1
+		ORDER BY component_id ASC`, positionID)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer rows.Close()
+
+	components := []DefiPositionComponent{}
+	for rows.Next() {
+		var c DefiPositionComponent
+		var assetType, assetCode, assetIssuer, assetContractID, symbol, amount, value, price, priceSource sql.NullString
+		var decimals sql.NullInt32
+		var metadataRaw []byte
+		if err := rows.Scan(&c.ComponentID, &c.ComponentType, &assetType, &assetCode, &assetIssuer, &assetContractID, &symbol, &decimals, &amount, &value, &price, &priceSource, &metadataRaw); err != nil {
+			return nil, nil, err
+		}
+		c.Asset = buildDefiAsset(assetType, assetCode, assetIssuer, assetContractID, symbol, decimals)
+		c.Amount = nullableString(amount.String)
+		c.Value = nullableString(value.String)
+		c.Price = nullableString(price.String)
+		c.PriceSource = nullableString(priceSource.String)
+		c.MetadataJSON = jsonObject(metadataRaw)
+		components = append(components, c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, nil, err
+	}
+	return position, components, nil
+}
+
+func scanDefiPositionSingleRow(row *sql.Row) (*DefiPosition, error) {
+	var position DefiPosition
+	var protocolVersion, accountAddress, relatedAddress, marketID, marketAddress, positionKeyHash sql.NullString
+	var assetType, assetCode, assetIssuer, assetContractID, symbol sql.NullString
+	var decimals sql.NullInt32
+	var depositAmount, borrowAmount, shareAmount, claimableRewardAmount sql.NullString
+	var depositValue, borrowedValue, currentValue, netValue sql.NullString
+	var currentReturnValue, currentReturnPercent, claimableRewardsValue sql.NullString
+	var healthFactor, ltv, collateralRatio, liquidationThreshold, riskStatus sql.NullString
+	var protocolStateRaw, valuationRaw, sourceRaw []byte
+	var asOfTime, lastUpdatedAt time.Time
+	if err := row.Scan(
+		&position.PositionID, &position.ProtocolID, &protocolVersion, &position.PositionType, &position.Status,
+		&position.OwnerAddress, &accountAddress, &relatedAddress, &marketID, &marketAddress, &positionKeyHash,
+		&assetType, &assetCode, &assetIssuer, &assetContractID, &symbol, &decimals,
+		&position.QuoteCurrency,
+		&depositAmount, &borrowAmount, &shareAmount, &claimableRewardAmount,
+		&depositValue, &borrowedValue, &currentValue, &netValue,
+		&currentReturnValue, &currentReturnPercent, &claimableRewardsValue,
+		&healthFactor, &ltv, &collateralRatio, &liquidationThreshold, &riskStatus,
+		&protocolStateRaw, &valuationRaw, &sourceRaw,
+		&position.AsOfLedger, &asOfTime, &position.LastUpdatedLedger, &lastUpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+	position.ProtocolVersion = nullableString(protocolVersion.String)
+	position.AccountAddress = nullableString(accountAddress.String)
+	position.RelatedAddress = nullableString(relatedAddress.String)
+	position.MarketID = nullableString(marketID.String)
+	position.MarketAddress = nullableString(marketAddress.String)
+	position.PositionKeyHash = nullableString(positionKeyHash.String)
+	position.UnderlyingAsset = buildDefiAsset(assetType, assetCode, assetIssuer, assetContractID, symbol, decimals)
+	position.DepositAmount = nullableString(depositAmount.String)
+	position.BorrowAmount = nullableString(borrowAmount.String)
+	position.ShareAmount = nullableString(shareAmount.String)
+	position.ClaimableRewardAmount = nullableString(claimableRewardAmount.String)
+	position.DepositValue = nullableString(depositValue.String)
+	position.BorrowedValue = nullableString(borrowedValue.String)
+	position.CurrentValue = nullableString(currentValue.String)
+	position.NetValue = nullableString(netValue.String)
+	position.CurrentReturnValue = nullableString(currentReturnValue.String)
+	position.CurrentReturnPercent = nullableString(currentReturnPercent.String)
+	position.ClaimableRewardsValue = nullableString(claimableRewardsValue.String)
+	position.HealthFactor = nullableString(healthFactor.String)
+	position.LTV = nullableString(ltv.String)
+	position.CollateralRatio = nullableString(collateralRatio.String)
+	position.LiquidationThreshold = nullableString(liquidationThreshold.String)
+	position.RiskStatus = nullableString(riskStatus.String)
+	position.ProtocolStateJSON = jsonObject(protocolStateRaw)
+	position.ValuationJSON = jsonObject(valuationRaw)
+	position.SourceJSON = jsonObject(sourceRaw)
+	position.AsOfTime = asOfTime.UTC().Format(time.RFC3339)
+	position.LastUpdatedAt = lastUpdatedAt.UTC().Format(time.RFC3339)
+	return &position, nil
+}
+
+func scanDefiPositionRow(rows *sql.Rows) (DefiPosition, error) {
+	return scanDefiPositionCommon(func(dest ...any) error {
+		return rows.Scan(dest...)
+	})
+}
+
+func scanDefiPositionCommon(scan func(dest ...any) error) (DefiPosition, error) {
+	var position DefiPosition
+	var protocolVersion, accountAddress, relatedAddress, marketID, marketAddress, positionKeyHash sql.NullString
+	var assetType, assetCode, assetIssuer, assetContractID, symbol sql.NullString
+	var decimals sql.NullInt32
+	var depositAmount, borrowAmount, shareAmount, claimableRewardAmount sql.NullString
+	var depositValue, borrowedValue, currentValue, netValue sql.NullString
+	var currentReturnValue, currentReturnPercent, claimableRewardsValue sql.NullString
+	var healthFactor, ltv, collateralRatio, liquidationThreshold, riskStatus sql.NullString
+	var protocolStateRaw, valuationRaw, sourceRaw []byte
+	var asOfTime, lastUpdatedAt time.Time
+	if err := scan(
+		&position.PositionID, &position.ProtocolID, &protocolVersion, &position.PositionType, &position.Status,
+		&position.OwnerAddress, &accountAddress, &relatedAddress, &marketID, &marketAddress, &positionKeyHash,
+		&assetType, &assetCode, &assetIssuer, &assetContractID, &symbol, &decimals,
+		&position.QuoteCurrency,
+		&depositAmount, &borrowAmount, &shareAmount, &claimableRewardAmount,
+		&depositValue, &borrowedValue, &currentValue, &netValue,
+		&currentReturnValue, &currentReturnPercent, &claimableRewardsValue,
+		&healthFactor, &ltv, &collateralRatio, &liquidationThreshold, &riskStatus,
+		&protocolStateRaw, &valuationRaw, &sourceRaw,
+		&position.AsOfLedger, &asOfTime, &position.LastUpdatedLedger, &lastUpdatedAt,
+	); err != nil {
+		return DefiPosition{}, err
+	}
+	position.ProtocolVersion = nullableString(protocolVersion.String)
+	position.AccountAddress = nullableString(accountAddress.String)
+	position.RelatedAddress = nullableString(relatedAddress.String)
+	position.MarketID = nullableString(marketID.String)
+	position.MarketAddress = nullableString(marketAddress.String)
+	position.PositionKeyHash = nullableString(positionKeyHash.String)
+	position.UnderlyingAsset = buildDefiAsset(assetType, assetCode, assetIssuer, assetContractID, symbol, decimals)
+	position.DepositAmount = nullableString(depositAmount.String)
+	position.BorrowAmount = nullableString(borrowAmount.String)
+	position.ShareAmount = nullableString(shareAmount.String)
+	position.ClaimableRewardAmount = nullableString(claimableRewardAmount.String)
+	position.DepositValue = nullableString(depositValue.String)
+	position.BorrowedValue = nullableString(borrowedValue.String)
+	position.CurrentValue = nullableString(currentValue.String)
+	position.NetValue = nullableString(netValue.String)
+	position.CurrentReturnValue = nullableString(currentReturnValue.String)
+	position.CurrentReturnPercent = nullableString(currentReturnPercent.String)
+	position.ClaimableRewardsValue = nullableString(claimableRewardsValue.String)
+	position.HealthFactor = nullableString(healthFactor.String)
+	position.LTV = nullableString(ltv.String)
+	position.CollateralRatio = nullableString(collateralRatio.String)
+	position.LiquidationThreshold = nullableString(liquidationThreshold.String)
+	position.RiskStatus = nullableString(riskStatus.String)
+	position.ProtocolStateJSON = jsonObject(protocolStateRaw)
+	position.ValuationJSON = jsonObject(valuationRaw)
+	position.SourceJSON = jsonObject(sourceRaw)
+	position.AsOfTime = asOfTime.UTC().Format(time.RFC3339)
+	position.LastUpdatedAt = lastUpdatedAt.UTC().Format(time.RFC3339)
+	return position, nil
+}

--- a/obsrvr-lake/stellar-query-api/go/tx_semantic_fast_path.go
+++ b/obsrvr-lake/stellar-query-api/go/tx_semantic_fast_path.go
@@ -14,7 +14,18 @@ func (h *DecodeHandlers) getTransactionForSemantic(ctx context.Context, txHash s
 	requestStart := time.Now()
 	if h.hotPathReader != nil {
 		hotStart := time.Now()
-		hotCtx, cancel := context.WithTimeout(ctx, 1200*time.Millisecond)
+		// Aggressive timeout (was 1200ms). The hot lookup is a tx_hash
+		// primary-key-ish read — if it's actually in hot it returns in
+		// <50ms. If it isn't, the old 1200ms wait was pure overhead per
+		// observed logs (/semantic reliably burned ~1.4s on the miss before
+		// fallback). Dropping to 200ms caps the worst-case miss cost at
+		// ~200ms with no impact on hot hits.
+		//
+		// Better long-term fix: maintain a cached "hot retention floor"
+		// ledger and skip the hot attempt entirely when the requested tx
+		// must be below it. That requires knowing the tx's ledger up-front
+		// (extra lookup) so saved for a follow-up.
+		hotCtx, cancel := context.WithTimeout(ctx, 200*time.Millisecond)
 		defer cancel()
 		decoded, err := h.hotPathReader.GetTransactionForDecode(hotCtx, txHash)
 		if err == nil {


### PR DESCRIPTION
This pull request introduces foundational support for DeFi protocol data in the serving database and includes example bootstrap data and configuration improvements. The main changes are the addition of a comprehensive DeFi schema, example SQL for seeding DeFi protocol and contract data, and updates to the Go service configuration and projector registration to support a new `tx_receipts` projector.

**DeFi serving schema and bootstrap data:**

* Added a new DeFi schema to `serving_schema.sql`, including tables for protocols, protocol contracts, markets, positions, position components, user totals, position/user history, prices, and protocol status, along with relevant indexes and constraints. This schema is designed to support a wide range of DeFi analytics and protocol tracking.
* Added `defi-seed-example.sql` as documentation and bootstrap material, providing example rows for `sv_defi_protocols` and `sv_defi_protocol_contracts` with testnet DeFi protocols and contracts. This is intended as a starting point for populating the DeFi registry in non-production environments.

**Serving projection processor configuration and registration:**

* Added a new `TxReceipts` projector to the `ProjectorsConfig` struct in `config.go`, allowing configuration of this projector via YAML.
* Set a default batch size of 256 for the `TxReceipts` projector in `LoadConfig`, with comments explaining the rationale based on memory and throughput considerations.
* Registered the `TxReceipts` projector in `buildProjectors` in `main.go`, so it is included in the list of active projectors when enabled in configuration.