### PR TITLE
update versioning

### DIFF
--- a/obsrvr-lake/docs/TIER1_VERSIONING_COMPATIBILITY_MATRIX.md
+++ b/obsrvr-lake/docs/TIER1_VERSIONING_COMPATIBILITY_MATRIX.md
@@ -1,0 +1,283 @@
+# Tier 1 Versioning Compatibility Matrix
+
+## Purpose
+
+This document is the **Tier 1 audit view** for incremental versioning.
+
+Tier 1 goal:
+
+> make version metadata real and preserve it across hot/cold boundaries
+
+For each representative table/path below, this matrix tracks whether:
+
+- schema includes `era_id` / `version_label`
+- writers populate them
+- flushers preserve them
+- readers preserve them
+- the path is considered Tier-1-safe today
+
+This is **not** the routing/read-enforcement audit for Tier 2/3.
+
+---
+
+## Legend
+
+- **Yes**: implemented and observed in current code
+- **Partial**: some path preserves metadata, but another important path still drops it
+- **No**: not implemented / metadata lost
+- **N/A**: not relevant for that step
+
+---
+
+## Summary Matrix
+
+| Dataset / Path | Hot schema | Hot write populates | Bronze cold schema | Hot→cold preserves | Cold reader preserves | Silver hot schema | Silver hot write preserves | Silver cold preserves | Tier 1 status |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| `transactions_row_v2` | Yes | Yes | Yes | Yes | N/A | N/A | N/A | N/A | **Good** |
+| `accounts_snapshot_v1` | Yes | Yes | Yes | Yes | Yes | `accounts_snapshot` / `accounts_current`: Yes | Yes | `accounts_snapshot` / `accounts_current`: Yes | **Good** |
+| `trustlines_snapshot_v1` | Yes | Yes | Yes | Yes | Yes | `trustlines_snapshot`: Yes / `trustlines_current`: Yes | Yes | Yes | **Good** |
+| `offers_snapshot_v1` | Yes | Yes | Yes | Yes | Yes | `offers_snapshot`: Yes / `offers_current`: Yes | Yes | Yes | **Good** |
+| `account_signers_snapshot_v1` | Yes | Yes | Yes | Yes | Yes | `account_signers_snapshot`: Yes | Yes | Yes | **Good** |
+| `contract_invocations_raw` | Source = bronze `operations_row_v2`: Yes | Yes | Source preserved in bronze cold ops | Yes | Yes | Yes | Yes | Yes | **Good** |
+| `contract_metadata` | Source = bronze `contract_creations_v1`: Yes | Yes | Yes | Yes | Hot reader only today | Yes | Yes | Yes | **Good** |
+
+---
+
+## Detailed Notes
+
+## 1. `transactions_row_v2`
+
+### Status
+- Hot schema: **Yes**
+- Hot writer populates: **Yes**
+- Bronze cold schema: **Yes**
+- Bronze flusher preserves: **Yes**
+- Tier 1: **Good**
+
+### Evidence
+- `stellar-postgres-ingester/go/types.go`
+- `stellar-postgres-ingester/go/writer.go`
+- `stellar-postgres-ingester/migrations/007_add_versioning_metadata.sql`
+- `postgres-ducklake-flusher/go/duckdb.go`
+- `postgres-ducklake-flusher/v3_bronze_schema.sql`
+
+### Notes
+This is the best simple proof that bronze-hot metadata is now real on a core append table.
+
+---
+
+## 2. `accounts_snapshot_v1` → `accounts_snapshot` / `accounts_current`
+
+### Status
+- Bronze hot schema/write: **Yes**
+- Bronze hot→cold preserve: **Yes**
+- Bronze cold reader preserve: **Yes**
+- Silver hot snapshot schema/write: **Yes**
+- Silver hot current schema/write: **Yes**
+- Silver hot→cold preserve: **Yes**
+- Tier 1: **Good**
+
+### Evidence
+- Bronze hot:
+  - `stellar-postgres-ingester/go/types.go`
+  - `stellar-postgres-ingester/go/writer.go`
+- Bronze cold:
+  - `postgres-ducklake-flusher/go/duckdb.go`
+  - `silver-realtime-transformer/go/bronze_cold_reader.go`
+- Silver hot:
+  - `silver-realtime-transformer/go/schema/init_silver_hot_complete.sql`
+  - `silver-realtime-transformer/go/transformer.go`
+  - `silver-realtime-transformer/go/types.go`
+  - `silver-realtime-transformer/go/silver_writer_batch.go`
+- Silver cold:
+  - `silver-cold-flusher/go/duckdb.go`
+  - `silver-cold-flusher/schema/silver_schema.sql`
+
+### Notes
+`accounts_*` is the cleanest end-to-end Tier 1 success path in the active runtime stack.
+
+---
+
+## 3. `trustlines_snapshot_v1` → `trustlines_snapshot` / `trustlines_current`
+
+### Status
+- Bronze hot schema/write: **Yes**
+- Bronze hot→cold preserve: **Yes**
+- Bronze cold reader preserve: **Yes**
+- Silver hot snapshot schema/write: **Yes**
+- Silver hot current schema/write: **Yes**
+- Silver cold preserve: **Yes**
+- Tier 1: **Good**
+
+### Evidence
+- Bronze hot:
+  - `stellar-postgres-ingester/go/writer.go`
+- Bronze cold:
+  - `postgres-ducklake-flusher/go/duckdb.go`
+  - `silver-realtime-transformer/go/bronze_cold_reader.go`
+- Silver snapshot path:
+  - `silver-realtime-transformer/go/transformer.go`
+  - `silver-realtime-transformer/go/types.go`
+  - `silver-realtime-transformer/go/silver_writer_batch.go`
+- Silver current path:
+  - `silver-realtime-transformer/go/schema/init_silver_hot_complete.sql`
+  - `silver-realtime-transformer/go/types.go`
+  - `silver-realtime-transformer/go/bronze_reader.go`
+  - `silver-realtime-transformer/go/bronze_cold_reader.go`
+  - `silver-realtime-transformer/go/transformer.go`
+  - `silver-realtime-transformer/go/silver_writer.go`
+  - `silver-realtime-transformer/go/silver_writer_batch.go`
+  - `silver-cold-flusher/go/duckdb.go`
+  - `silver-cold-flusher/go/silver_schema.go`
+  - `silver-cold-flusher/schema/silver_schema.sql`
+
+### Notes
+Both the snapshot/history path and the current-state path now preserve
+`era_id` / `version_label`.
+
+---
+
+## 4. `offers_snapshot_v1` → `offers_snapshot` / `offers_current`
+
+### Status
+- Bronze hot schema/write: **Yes**
+- Bronze hot→cold preserve: **Yes**
+- Bronze cold reader preserve: **Yes**
+- Silver hot snapshot schema/write: **Yes**
+- Silver hot current schema/write: **Yes**
+- Silver cold preserve: **Yes**
+- Tier 1: **Good**
+
+### Evidence
+- Bronze hot:
+  - `stellar-postgres-ingester/go/writer.go`
+- Bronze cold:
+  - `postgres-ducklake-flusher/go/duckdb.go`
+  - `silver-realtime-transformer/go/bronze_cold_reader.go`
+- Silver snapshot path:
+  - `silver-realtime-transformer/go/transformer.go`
+  - `silver-realtime-transformer/go/types.go`
+  - `silver-realtime-transformer/go/silver_writer_batch.go`
+- Silver current path:
+  - `silver-realtime-transformer/go/schema/init_silver_hot_complete.sql`
+  - `silver-realtime-transformer/go/types.go`
+  - `silver-realtime-transformer/go/bronze_reader.go`
+  - `silver-realtime-transformer/go/bronze_cold_reader.go`
+  - `silver-realtime-transformer/go/transformer.go`
+  - `silver-realtime-transformer/go/silver_writer.go`
+  - `silver-realtime-transformer/go/silver_writer_batch.go`
+  - `silver-cold-flusher/go/duckdb.go`
+  - `silver-cold-flusher/go/silver_schema.go`
+  - `silver-cold-flusher/schema/silver_schema.sql`
+
+### Notes
+Both the snapshot/history path and the current-state path now preserve
+`era_id` / `version_label`.
+
+---
+
+## 5. `account_signers_snapshot_v1` → `account_signers_snapshot`
+
+### Status
+- Bronze hot schema/write: **Yes**
+- Bronze hot→cold preserve: **Yes**
+- Bronze cold reader preserve: **Yes**
+- Silver hot snapshot schema/write: **Yes**
+- Silver cold preserve: **Yes**
+- Tier 1: **Good**
+
+### Evidence
+- `stellar-postgres-ingester/go/writer.go`
+- `postgres-ducklake-flusher/go/duckdb.go`
+- `silver-realtime-transformer/go/bronze_cold_reader.go`
+- `silver-realtime-transformer/go/transformer.go`
+- `silver-cold-flusher/schema/silver_schema.sql`
+
+### Notes
+This is another strong Tier 1 representative path because it is snapshot-only and avoids current-state ambiguity.
+
+---
+
+## 6. `contract_invocations_raw`
+
+### Status
+- Bronze source schema/write (`operations_row_v2`): **Yes**
+- Bronze hot→cold preserve: **Yes**
+- Bronze hot/cold readers preserve: **Yes**
+- Silver hot schema/write: **Yes**
+- Silver hot→cold preserve: **Yes**
+- Tier 1: **Good**
+
+### Evidence
+- Bronze source:
+  - `stellar-postgres-ingester/go/writer.go`
+  - `postgres-ducklake-flusher/go/duckdb.go`
+- Bronze readers:
+  - `silver-realtime-transformer/go/bronze_reader.go`
+  - `silver-realtime-transformer/go/bronze_cold_reader.go`
+- Silver hot:
+  - `silver-realtime-transformer/go/schema/init_silver_hot_complete.sql`
+  - `silver-realtime-transformer/go/types.go`
+  - `silver-realtime-transformer/go/transformer.go`
+  - `silver-realtime-transformer/go/silver_writer.go`
+  - `silver-realtime-transformer/go/silver_writer_batch.go`
+- Silver cold:
+  - `silver-cold-flusher/go/duckdb.go`
+  - `silver-cold-flusher/go/silver_schema.go`
+  - `silver-cold-flusher/schema/silver_schema.sql`
+
+### Notes
+This path was previously collapsing metadata in silver cold; it now preserves it.
+
+---
+
+## 7. `contract_metadata`
+
+### Status
+- Bronze source schema/write (`contract_creations_v1`): **Yes**
+- Bronze hot→cold preserve: **Yes**
+- Bronze reader preserve: **Hot reader only currently audited**
+- Silver hot schema/write: **Yes**
+- Silver hot→cold preserve: **Yes**
+- Tier 1: **Good**
+
+### Evidence
+- Bronze source:
+  - `stellar-postgres-ingester/go/writer.go`
+  - `postgres-ducklake-flusher/go/duckdb.go`
+- Silver hot:
+  - `silver-realtime-transformer/go/schema/init_silver_hot_complete.sql`
+  - `silver-realtime-transformer/go/transformer.go`
+  - `silver-realtime-transformer/go/silver_writer.go`
+  - `silver-realtime-transformer/go/silver_writer_batch.go`
+- Silver cold:
+  - `silver-cold-flusher/go/duckdb.go`
+  - `silver-cold-flusher/go/silver_schema.go`
+  - `silver-cold-flusher/schema/silver_schema.sql`
+
+### Notes
+This is Tier-1-good for preservation, but it still does **not** imply version-aware routing/selection.
+
+---
+
+## Remaining Tier 1 Gaps
+
+These are the main remaining Tier 1 gaps after the current implementation slice.
+
+### A. Tier 1 validation is representative, not exhaustive
+
+Current operational checks validate representative tables, but there is not yet a full table-by-table integration test proving hot and cold parity everywhere.
+
+Evidence:
+- `/home/tillman/Documents/infra/environments/prod/latitude/obsrvr-lake-testnet/scripts/10-verify.sh`
+
+---
+
+## Recommended Next Implementation Slice
+
+1. Add one integration-style validation for hot/cold parity on:
+   - `accounts_snapshot_v1`
+   - `contract_invocations_raw`
+   - `trustlines_snapshot_v1`
+
+That would move Tier 1 from **representatively working** to **nearly complete for active table families**.

--- a/obsrvr-lake/docs/TIER1_VERSIONING_COMPATIBILITY_MATRIX.md
+++ b/obsrvr-lake/docs/TIER1_VERSIONING_COMPATIBILITY_MATRIX.md
@@ -269,7 +269,7 @@ These are the main remaining Tier 1 gaps after the current implementation slice.
 Current operational checks validate representative tables, but there is not yet a full table-by-table integration test proving hot and cold parity everywhere.
 
 Evidence:
-- `/home/tillman/Documents/infra/environments/prod/latitude/obsrvr-lake-testnet/scripts/10-verify.sh`
+- operational validation script used in the deployment environment (`scripts/10-verify.sh` in infra)
 
 ---
 

--- a/obsrvr-lake/docs/VERSIONING_GAP_CHECKLIST.md
+++ b/obsrvr-lake/docs/VERSIONING_GAP_CHECKLIST.md
@@ -1,0 +1,392 @@
+# obsrvr-lake Incremental Versioning Gap Checklist
+
+## Purpose
+
+This document captures the current gap between:
+
+1. the **desired reconciliation-safe versioning model** described in
+   `/home/tillman/Documents/ttp-processor-demo/ducklake-ingestion-obsrvr-v3/INCREMENTAL_VERSIONING_GUIDE.md`
+2. the **currently implemented obsrvr-lake ingestion/query stack**
+
+It is intended to answer a practical operational question:
+
+> If we need to reingest a historical ledger range with corrected extraction logic,
+> can we safely keep old data, ingest corrected data alongside it, and route reads
+> to the corrected version?
+
+## Short Answer
+
+**Not end-to-end yet.**
+
+The repo already has substantial schema-level and partial pipeline support for:
+
+- `ledger_range`
+- `era_id`
+- `version_label`
+- snapshot history (`valid_to` in some silver tables)
+
+But the currently active stack does **not yet** provide a complete, reconciliation-safe versioning system.
+
+Main gaps:
+
+- hot bronze ingestion does not consistently populate `era_id` / `version_label`
+- some cold readers/flushers explicitly null them out
+- no active-era / active-version resolver was found in the current obsrvr-lake runtime path
+- no evidence that API queries enforce version filtering or overlay logic
+
+---
+
+## Desired End State
+
+A reconciliation-safe versioning system should support:
+
+- reingesting a ledger range with corrected logic without deleting old data
+- preserving previous versions for audit/debugging
+- selecting the active corrected version automatically in production reads
+- supporting explicit historical queries against older versions when needed
+
+Minimum required capabilities:
+
+- all bronze writes populate `era_id` and `version_label`
+- hot and cold paths preserve those fields consistently
+- metadata exists for active era/version per network/dataset
+- readers can choose:
+  - explicit version filter, or
+  - latest-version overlay
+- silver transformations and APIs use version-aware reads
+
+---
+
+## Audit Summary
+
+| Component | `ledger_range` | `era_id` / `version_label` in schema | Populates them | Preserves them | Routes by them | Reconciliation-safe today? |
+|---|---:|---:|---:|---:|---:|---:|
+| `stellar-postgres-ingester` | Yes | Partial / schema-aware | No (active hot path) | N/A | No | No |
+| `stellar-history-loader` | Yes | Yes | Yes | Yes | No | Partial |
+| `postgres-ducklake-flusher` | Yes | Yes | Depends on source | Partial | No | Partial |
+| `silver-realtime-transformer` hot bronze reader/writer | Yes | Yes | Reads/writes some | Partial | No | Partial |
+| `silver-realtime-transformer` cold reader | Yes | Yes in target shape | No (often nulls) | No | No | No |
+| `silver-cold-flusher` | Yes | Yes | Partial | Partial / sometimes nulls | No | No |
+| `stellar-query-api` | Yes | Yes | N/A | Returns fields | No | No |
+| End-to-end runtime | Yes | Partial | Inconsistent | Inconsistent | No | No |
+
+---
+
+# Component Checklist
+
+## 1. `stellar-postgres-ingester`
+
+### Current findings
+
+- Uses `ledger_range` actively.
+- Local runtime structs do **not** consistently carry `EraID` / `VersionLabel`.
+- Conversion helpers from `stellar-extract` explicitly drop library-only fields.
+- Active PostgreSQL insert paths were observed writing `ledger_range` but not consistently writing `era_id` / `version_label`.
+
+### Evidence
+
+- `stellar-postgres-ingester/go/types.go`
+- `stellar-postgres-ingester/go/writer.go`
+- `stellar-postgres-ingester/go/fix_all_inserts.py`
+
+### Gaps
+
+- [ ] Add `EraID` to all relevant hot bronze runtime structs.
+- [ ] Add `VersionLabel` to all relevant hot bronze runtime structs.
+- [ ] Preserve `EraID` / `VersionLabel` in conversion helpers from `stellar-extract`.
+- [ ] Update all hot bronze insert statements to write `era_id` / `version_label`.
+- [ ] Ensure conflict/update clauses behave correctly when a new version is ingested for overlapping ledger ranges.
+- [ ] Decide whether hot bronze should allow coexistence of multiple versions or remain single-version with explicit correction workflow.
+
+### Risk if not fixed
+
+Historical replay into corrected versions cannot be safely represented in hot bronze, even if downstream schemas support it.
+
+---
+
+## 2. `stellar-history-loader`
+
+### Current findings
+
+- Strongest version-aware component found.
+- Parquet writer includes `era_id` and `version_label`.
+- Validation explicitly checks that `version_label` is populated.
+
+### Evidence
+
+- `stellar-history-loader/go/parquet_writer.go`
+- `stellar-history-loader/go/validate.go`
+
+### Gaps
+
+- [ ] Confirm `era_id` is always populated when intended, not just optional.
+- [ ] Document the canonical rules for setting `era_id` and `version_label` during replay.
+- [ ] Standardize version naming convention across loader and streaming paths.
+- [ ] Define whether this loader is the preferred correction/replay mechanism.
+
+### Risk if not fixed
+
+Historical loader may be version-aware while streaming hot ingestion remains version-blind, causing divergence between hot and cold semantics.
+
+---
+
+## 3. `postgres-ducklake-flusher`
+
+### Current findings
+
+- Bronze DuckLake schemas include `era_id` / `version_label`.
+- Some explicit-column table mappings preserve those columns.
+- Actual correctness depends on source PostgreSQL tables having those values.
+
+### Evidence
+
+- `postgres-ducklake-flusher/schema/bronze_schema.sql`
+- `postgres-ducklake-flusher/go/duckdb.go`
+
+### Gaps
+
+- [ ] Verify every flushed bronze table preserves `era_id` / `version_label`.
+- [ ] Remove any remaining positional/implicit writes that can misalign version columns.
+- [ ] Add validation/health checks for missing `version_label` in flushed bronze cold data.
+- [ ] Define whether flusher should reject rows with missing version metadata for versioned datasets.
+
+### Risk if not fixed
+
+Cold storage may appear version-capable in schema while actually storing null or inconsistent version metadata.
+
+---
+
+## 4. `silver-realtime-transformer` hot path
+
+### Current findings
+
+- Bronze hot reader selects `era_id` / `version_label` from snapshot tables.
+- Silver writer includes `era_id` / `version_label` in several current/snapshot inserts.
+- Snapshot/history path has some SCD-style `valid_to` handling.
+- Some current-state upsert conflict clauses do not appear to update `era_id` / `version_label`.
+
+### Evidence
+
+- `silver-realtime-transformer/go/bronze_reader.go`
+- `silver-realtime-transformer/go/silver_writer.go`
+- `silver-realtime-transformer/go/silver_writer_batch.go`
+
+### Gaps
+
+- [ ] Audit every `*_current` upsert to ensure `era_id` / `version_label` are handled intentionally.
+- [ ] Define whether current-state tables are single active version only, or multi-version aware.
+- [ ] Ensure silver snapshot writes preserve version metadata everywhere, not just selected tables.
+- [ ] Add tests for overlapping-version inputs on the same ledger range.
+- [ ] Decide how `valid_to` should interact with corrected replay versions.
+
+### Risk if not fixed
+
+Silver may preserve version metadata in some records while still resolving current state using non-versioned upsert semantics.
+
+---
+
+## 5. `silver-realtime-transformer` cold bronze reader
+
+### Current findings
+
+- Multiple cold queries explicitly project:
+  - `NULL AS era_id`
+  - `NULL AS version_label`
+
+### Evidence
+
+- `silver-realtime-transformer/go/bronze_cold_reader.go`
+
+### Gaps
+
+- [ ] Remove `NULL AS era_id` from cold bronze reader queries where source data has these fields.
+- [ ] Remove `NULL AS version_label` from cold bronze reader queries where source data has these fields.
+- [ ] Confirm cold Bronze schemas and Parquet files actually contain the fields for all relevant tables.
+- [ ] Add tests verifying hot and cold bronze readers return the same version metadata semantics.
+
+### Risk if not fixed
+
+Any replay/versioning model breaks across hot/cold boundaries, because cold reads erase the metadata required for routing.
+
+---
+
+## 6. `silver-cold-flusher`
+
+### Current findings
+
+- Silver DuckLake schemas include `era_id` / `version_label`.
+- Some flush paths explicitly insert `NULL AS era_id, NULL AS version_label`.
+
+### Evidence
+
+- `silver-cold-flusher/schema/silver_current_state_ducklake.sql`
+- `silver-cold-flusher/schema/silver_schema.sql`
+- `silver-cold-flusher/go/duckdb.go`
+
+### Gaps
+
+- [ ] Audit every silver cold flush path for preservation of version metadata.
+- [ ] Eliminate hardcoded null version fields where upstream tables already contain them.
+- [ ] Define whether silver cold should support overlapping versions in the same ledger range.
+- [ ] Add validation queries checking for null `version_label` in versioned silver datasets.
+
+### Risk if not fixed
+
+Silver cold may silently collapse version semantics even if silver hot preserved them.
+
+---
+
+## 7. `stellar-query-api`
+
+### Current findings
+
+- Readers select `era_id` / `version_label` from hot and cold sources.
+- Query service includes those fields in API responses when present.
+- No evidence was found of:
+  - active era lookup
+  - active version lookup
+  - version filter enforcement
+  - overlay/latest-version windowing
+
+### Evidence
+
+- `stellar-query-api/go/hot_reader.go`
+- `stellar-query-api/go/cold_reader.go`
+- `stellar-query-api/go/query_service.go`
+
+### Gaps
+
+- [ ] Introduce version-aware query mode for production paths.
+- [ ] Support explicit `era_id` / `version_label` filtering in readers.
+- [ ] Add overlay/latest-version query strategy for overlapping versions.
+- [ ] Decide whether version selection belongs in API handlers, readers, or a shared resolver library.
+- [ ] Add tests proving APIs return corrected-version rows instead of stale rows when overlap exists.
+
+### Risk if not fixed
+
+The API can expose version metadata but cannot safely choose the correct version when multiple versions overlap.
+
+---
+
+# Cross-Cutting Gaps
+
+## A. No shared active version metadata layer found
+
+### Gap
+
+No evidence was found in the active obsrvr-lake runtime path for:
+
+- `_meta_eras`
+- active version metadata tables
+- status=`active` routing
+- shared resolver API
+
+### Checklist
+
+- [ ] Define canonical metadata tables for active era/version by network and dataset.
+- [ ] Define lineage model (`supersedes`, `reconciles`, `reprocessed_from`, etc.).
+- [ ] Create operational commands/workflow for activating a corrected version.
+
+---
+
+## B. No shared resolver/query builder found
+
+### Gap
+
+The richer behavior described in `INCREMENTAL_VERSIONING_GUIDE.md` was not found in the current obsrvr-lake runtime path.
+
+### Checklist
+
+- [ ] Build shared resolver/query builder for active version selection.
+- [ ] Support two query modes:
+  - [ ] explicit version filter
+  - [ ] latest-version overlay
+- [ ] Reuse resolver from silver transformers, APIs, exports, and analyst tooling.
+
+---
+
+## C. Hot/cold semantics are not aligned
+
+### Gap
+
+Even where schemas support version fields, some hot/cold readers and flushers do not preserve them consistently.
+
+### Checklist
+
+- [ ] Produce a table-by-table compatibility matrix for hot vs cold version metadata.
+- [ ] Ensure every table with `era_id` / `version_label` preserves them in both directions.
+- [ ] Add integration tests comparing hot and cold query results for the same ledger range.
+
+---
+
+## D. Replay workflow is not yet productized
+
+### Gap
+
+There is no clearly documented, reconciliation-safe replay workflow that guarantees corrected data can coexist with previous data and be selected deterministically.
+
+### Checklist
+
+- [ ] Define replay process for ledger range correction.
+- [ ] Define how corrected data is tagged (`era_id`, `version_label`).
+- [ ] Define validation steps before activation.
+- [ ] Define rollback steps.
+- [ ] Define observability/health checks for mixed-version ranges.
+
+---
+
+# Priority Plan
+
+## Phase 1: Make bronze hot version-capable
+
+- [ ] Add `EraID` / `VersionLabel` to hot ingester structs.
+- [ ] Persist them in all bronze hot tables.
+- [ ] Add tests proving values survive extraction → write.
+
+## Phase 2: Preserve version metadata across hot/cold
+
+- [ ] Remove `NULL AS era_id/version_label` from cold readers/flushers where not appropriate.
+- [ ] Validate all bronze and silver cold tables retain version metadata.
+
+## Phase 3: Add routing metadata + resolver
+
+- [ ] Implement active version metadata tables.
+- [ ] Implement shared resolver/query helper.
+- [ ] Add explicit filter and latest-overlay modes.
+
+## Phase 4: Make silver/API version-aware
+
+- [ ] Update silver transformers to use version-aware reads.
+- [ ] Update query API to route by active version.
+- [ ] Add overlapping-version tests.
+
+## Phase 5: Operationalize replay
+
+- [ ] Write runbook for partial replay with corrected logic.
+- [ ] Validate on a small historical range.
+- [ ] Add dashboards/alerts for overlapping version ranges.
+
+---
+
+# Decision Log / Open Questions
+
+- [ ] Should hot PostgreSQL retain multiple versions side-by-side, or only cold/DuckLake?
+- [ ] Is `stellar-history-loader` the canonical correction path, or should streaming/hot also support corrected overlap directly?
+- [ ] Should `era_id` represent protocol era, replay campaign, or both?
+- [ ] Should `version_label` be global (`v1`, `v2`) or dataset/campaign-specific (`config-fix-2026-04-v1`)?
+- [ ] How should current-state silver tables behave when two versions overlap for the same business key?
+
+---
+
+# Recommended Next Implementation Slice
+
+If the goal is the **smallest useful step**, start here:
+
+1. make `stellar-postgres-ingester` actually populate `era_id` / `version_label`
+2. stop nulling those fields in cold readers/flushers
+3. add one shared query helper that filters by explicit version
+4. test on one dataset first:
+   - `config_settings_snapshot_v1`
+   - or `accounts_snapshot_v1`
+
+That would move the system from **schema-ready but operationally incomplete** to **minimally version-aware**.

--- a/obsrvr-lake/docs/VERSIONING_GAP_CHECKLIST.md
+++ b/obsrvr-lake/docs/VERSIONING_GAP_CHECKLIST.md
@@ -5,7 +5,7 @@
 This document captures the current gap between:
 
 1. the **desired reconciliation-safe versioning model** described in
-   `/home/tillman/Documents/ttp-processor-demo/ducklake-ingestion-obsrvr-v3/INCREMENTAL_VERSIONING_GUIDE.md`
+   `../ducklake-ingestion-obsrvr-v3/INCREMENTAL_VERSIONING_GUIDE.md`
 2. the **currently implemented obsrvr-lake ingestion/query stack**
 
 It is intended to answer a practical operational question:
@@ -29,7 +29,7 @@ But the currently active stack does **not yet** provide a complete, reconciliati
 
 Main gaps:
 
-- hot bronze ingestion does not consistently populate `era_id` / `version_label`
+- hot bronze ingestion now broadly populates `era_id` / `version_label`, but end-to-end validation for all paths is still incomplete
 - some cold readers/flushers explicitly null them out
 - no active-era / active-version resolver was found in the current obsrvr-lake runtime path
 - no evidence that API queries enforce version filtering or overlay logic
@@ -61,7 +61,7 @@ Minimum required capabilities:
 
 | Component | `ledger_range` | `era_id` / `version_label` in schema | Populates them | Preserves them | Routes by them | Reconciliation-safe today? |
 |---|---:|---:|---:|---:|---:|---:|
-| `stellar-postgres-ingester` | Yes | Partial / schema-aware | No (active hot path) | N/A | No | No |
+| `stellar-postgres-ingester` | Yes | Partial / schema-aware | Yes | N/A | No | No |
 | `stellar-history-loader` | Yes | Yes | Yes | Yes | No | Partial |
 | `postgres-ducklake-flusher` | Yes | Yes | Depends on source | Partial | No | Partial |
 | `silver-realtime-transformer` hot bronze reader/writer | Yes | Yes | Reads/writes some | Partial | No | Partial |
@@ -79,9 +79,9 @@ Minimum required capabilities:
 ### Current findings
 
 - Uses `ledger_range` actively.
-- Local runtime structs do **not** consistently carry `EraID` / `VersionLabel`.
-- Conversion helpers from `stellar-extract` explicitly drop library-only fields.
-- Active PostgreSQL insert paths were observed writing `ledger_range` but not consistently writing `era_id` / `version_label`.
+- Runtime structs and writers now broadly carry and write `EraID` / `VersionLabel`.
+- PostgreSQL migrations add versioning columns across the active bronze tables.
+- Remaining gap is end-to-end validation and reconciliation-aware routing, not basic field population.
 
 ### Evidence
 
@@ -91,10 +91,10 @@ Minimum required capabilities:
 
 ### Gaps
 
-- [ ] Add `EraID` to all relevant hot bronze runtime structs.
-- [ ] Add `VersionLabel` to all relevant hot bronze runtime structs.
-- [ ] Preserve `EraID` / `VersionLabel` in conversion helpers from `stellar-extract`.
-- [ ] Update all hot bronze insert statements to write `era_id` / `version_label`.
+- [x] Add `EraID` to all relevant hot bronze runtime structs.
+- [x] Add `VersionLabel` to all relevant hot bronze runtime structs.
+- [x] Preserve `EraID` / `VersionLabel` in conversion helpers from `stellar-extract`.
+- [x] Update active hot bronze insert statements to write `era_id` / `version_label`.
 - [ ] Ensure conflict/update clauses behave correctly when a new version is ingested for overlapping ledger ranges.
 - [ ] Decide whether hot bronze should allow coexistence of multiple versions or remain single-version with explicit correction workflow.
 

--- a/obsrvr-lake/postgres-ducklake-flusher/go/bronze_schema.go
+++ b/obsrvr-lake/postgres-ducklake-flusher/go/bronze_schema.go
@@ -157,6 +157,42 @@ func (c *DuckDBClient) applyBronzeMigrations(ctx context.Context) error {
 		},
 	}
 
+	versionedTables := []string{
+		"ledgers_row_v2",
+		"transactions_row_v2",
+		"operations_row_v2",
+		"effects_row_v1",
+		"trades_row_v1",
+		"accounts_snapshot_v1",
+		"offers_snapshot_v1",
+		"trustlines_snapshot_v1",
+		"account_signers_snapshot_v1",
+		"claimable_balances_snapshot_v1",
+		"liquidity_pools_snapshot_v1",
+		"config_settings_snapshot_v1",
+		"ttl_snapshot_v1",
+		"evicted_keys_state_v1",
+		"contract_events_stream_v1",
+		"contract_data_snapshot_v1",
+		"contract_code_snapshot_v1",
+		"native_balances_snapshot_v1",
+		"restored_keys_state_v1",
+		"contract_creations_v1",
+		"token_transfers_stream_v1",
+	}
+	for _, table := range versionedTables {
+		migrations = append(migrations,
+			migration{
+				name: fmt.Sprintf("%s.era_id", table),
+				sql:  fmt.Sprintf(`ALTER TABLE %s.%s ADD COLUMN IF NOT EXISTS era_id VARCHAR`, qualified, table),
+			},
+			migration{
+				name: fmt.Sprintf("%s.version_label", table),
+				sql:  fmt.Sprintf(`ALTER TABLE %s.%s ADD COLUMN IF NOT EXISTS version_label VARCHAR`, qualified, table),
+			},
+		)
+	}
+
 	for _, m := range migrations {
 		if _, err := c.db.ExecContext(ctx, m.sql); err != nil {
 			// DuckLake may report "already exists" even with IF NOT EXISTS on

--- a/obsrvr-lake/postgres-ducklake-flusher/go/duckdb.go
+++ b/obsrvr-lake/postgres-ducklake-flusher/go/duckdb.go
@@ -233,7 +233,8 @@ var explicitColumnTables = map[string]string{
 		operation_index, event_type, "from", "to",
 		asset, asset_type, asset_code, asset_issuer,
 		amount, amount_raw, contract_id,
-		closed_at, created_at, ledger_range`,
+		closed_at, created_at, ledger_range,
+		era_id, version_label`,
 }
 
 // buildFlushSQL constructs the INSERT...SELECT SQL for flushing a table.

--- a/obsrvr-lake/postgres-ducklake-flusher/v3_bronze_schema.sql
+++ b/obsrvr-lake/postgres-ducklake-flusher/v3_bronze_schema.sql
@@ -537,5 +537,7 @@ CREATE TABLE IF NOT EXISTS bronze.token_transfers_stream_v1 (
     contract_id       TEXT,
     closed_at         TIMESTAMP,
     created_at        TIMESTAMP,
-    ledger_range      INTEGER
+    ledger_range      INTEGER,
+    era_id            TEXT,
+    version_label     TEXT
 );

--- a/obsrvr-lake/silver-cold-flusher/go/duckdb.go
+++ b/obsrvr-lake/silver-cold-flusher/go/duckdb.go
@@ -159,6 +159,66 @@ func (c *DuckDBClient) FlushTable(tableName string, watermark int64, pgConnStr s
 			FROM postgres_scan('%s', 'public', '%s')
 			WHERE last_modified_ledger > %d AND last_modified_ledger <= %d
 		`, c.config.CatalogName, c.config.SchemaName, tableName, pgConnStr, tableName, lastFlushed, watermark)
+	case "trustlines_current":
+		// Versioning columns may be appended at the tail of silver_hot via
+		// ALTER TABLE on existing deployments, while fresh schemas can place
+		// them before inserted_at/updated_at. Use an explicit projection so
+		// hot/cold flushing is stable across both layouts.
+		query = fmt.Sprintf(`
+			INSERT INTO %s.%s.%s
+			SELECT
+				account_id,
+				asset_type,
+				asset_issuer,
+				asset_code,
+				liquidity_pool_id,
+				balance,
+				trust_line_limit,
+				buying_liabilities,
+				selling_liabilities,
+				flags,
+				last_modified_ledger,
+				ledger_sequence,
+				created_at,
+				sponsor,
+				ledger_range,
+				era_id,
+				version_label,
+				inserted_at,
+				updated_at
+			FROM postgres_scan('%s', 'public', '%s')
+			WHERE last_modified_ledger > %d AND last_modified_ledger <= %d
+		`, c.config.CatalogName, c.config.SchemaName, tableName, pgConnStr, tableName, lastFlushed, watermark)
+	case "offers_current":
+		// Same column-order issue as trustlines_current.
+		query = fmt.Sprintf(`
+			INSERT INTO %s.%s.%s
+			SELECT
+				offer_id,
+				seller_id,
+				selling_asset_type,
+				selling_asset_code,
+				selling_asset_issuer,
+				buying_asset_type,
+				buying_asset_code,
+				buying_asset_issuer,
+				amount,
+				price_n,
+				price_d,
+				price,
+				flags,
+				last_modified_ledger,
+				ledger_sequence,
+				created_at,
+				sponsor,
+				ledger_range,
+				era_id,
+				version_label,
+				inserted_at,
+				updated_at
+			FROM postgres_scan('%s', 'public', '%s')
+			WHERE last_modified_ledger > %d AND last_modified_ledger <= %d
+		`, c.config.CatalogName, c.config.SchemaName, tableName, pgConnStr, tableName, lastFlushed, watermark)
 	case "claimable_balances_current":
 		// Source table in silver_hot has 15 columns, while DuckLake carries two
 		// additional compatibility columns (claimants, asset). Project explicitly.
@@ -225,13 +285,12 @@ func (c *DuckDBClient) FlushSnapshotTable(tableName string, watermark int64, pgC
 			WHERE ledger_sequence > %d AND ledger_sequence <= %d
 		`, c.config.CatalogName, c.config.SchemaName, tableName, pgConnStr, tableName, lastFlushed, watermark)
 	} else if tableName == "contract_invocations_raw" {
-		// PG has 12 columns, DuckLake has 14 (extra: era_id, version_label)
 		query = fmt.Sprintf(`
 			INSERT INTO %s.%s.%s
 			SELECT ledger_sequence, transaction_index, operation_index, transaction_hash,
 			       source_account, contract_id, function_name, arguments_json,
 			       successful, closed_at, ledger_range, inserted_at,
-			       NULL AS era_id, NULL AS version_label
+			       era_id, version_label
 			FROM postgres_scan('%s', 'public', '%s')
 			WHERE ledger_sequence > %d AND ledger_sequence <= %d
 		`, c.config.CatalogName, c.config.SchemaName, tableName, pgConnStr, tableName, lastFlushed, watermark)
@@ -266,11 +325,10 @@ func (c *DuckDBClient) FlushTableWithColumn(tableName string, watermark int64, p
 	var query string
 
 	if tableName == "contract_metadata" {
-		// PG has 6 columns, DuckLake has 8 (extra: era_id, version_label)
 		query = fmt.Sprintf(`
 			INSERT INTO %s.%s.%s
 			SELECT contract_id, creator_address, wasm_hash, created_ledger,
-			       created_at, inserted_at, NULL AS era_id, NULL AS version_label
+			       created_at, inserted_at, era_id, version_label
 			FROM postgres_scan('%s', 'public', '%s')
 			WHERE %s > %d AND %s <= %d
 		`, c.config.CatalogName, c.config.SchemaName, tableName, pgConnStr, tableName, column, lastFlushed, column, watermark)

--- a/obsrvr-lake/silver-cold-flusher/go/duckdb.go
+++ b/obsrvr-lake/silver-cold-flusher/go/duckdb.go
@@ -165,7 +165,27 @@ func (c *DuckDBClient) FlushTable(tableName string, watermark int64, pgConnStr s
 		// them before inserted_at/updated_at. Use an explicit projection so
 		// hot/cold flushing is stable across both layouts.
 		query = fmt.Sprintf(`
-			INSERT INTO %s.%s.%s
+			INSERT INTO %s.%s.%s (
+				account_id,
+				asset_type,
+				asset_issuer,
+				asset_code,
+				liquidity_pool_id,
+				balance,
+				trust_line_limit,
+				buying_liabilities,
+				selling_liabilities,
+				flags,
+				last_modified_ledger,
+				ledger_sequence,
+				created_at,
+				sponsor,
+				ledger_range,
+				era_id,
+				version_label,
+				inserted_at,
+				updated_at
+			)
 			SELECT
 				account_id,
 				asset_type,
@@ -192,7 +212,30 @@ func (c *DuckDBClient) FlushTable(tableName string, watermark int64, pgConnStr s
 	case "offers_current":
 		// Same column-order issue as trustlines_current.
 		query = fmt.Sprintf(`
-			INSERT INTO %s.%s.%s
+			INSERT INTO %s.%s.%s (
+				offer_id,
+				seller_id,
+				selling_asset_type,
+				selling_asset_code,
+				selling_asset_issuer,
+				buying_asset_type,
+				buying_asset_code,
+				buying_asset_issuer,
+				amount,
+				price_n,
+				price_d,
+				price,
+				flags,
+				last_modified_ledger,
+				ledger_sequence,
+				created_at,
+				sponsor,
+				ledger_range,
+				era_id,
+				version_label,
+				inserted_at,
+				updated_at
+			)
 			SELECT
 				offer_id,
 				seller_id,
@@ -286,7 +329,22 @@ func (c *DuckDBClient) FlushSnapshotTable(tableName string, watermark int64, pgC
 		`, c.config.CatalogName, c.config.SchemaName, tableName, pgConnStr, tableName, lastFlushed, watermark)
 	} else if tableName == "contract_invocations_raw" {
 		query = fmt.Sprintf(`
-			INSERT INTO %s.%s.%s
+			INSERT INTO %s.%s.%s (
+				ledger_sequence,
+				transaction_index,
+				operation_index,
+				transaction_hash,
+				source_account,
+				contract_id,
+				function_name,
+				arguments_json,
+				successful,
+				closed_at,
+				ledger_range,
+				inserted_at,
+				era_id,
+				version_label
+			)
 			SELECT ledger_sequence, transaction_index, operation_index, transaction_hash,
 			       source_account, contract_id, function_name, arguments_json,
 			       successful, closed_at, ledger_range, inserted_at,
@@ -326,7 +384,16 @@ func (c *DuckDBClient) FlushTableWithColumn(tableName string, watermark int64, p
 
 	if tableName == "contract_metadata" {
 		query = fmt.Sprintf(`
-			INSERT INTO %s.%s.%s
+			INSERT INTO %s.%s.%s (
+				contract_id,
+				creator_address,
+				wasm_hash,
+				created_ledger,
+				created_at,
+				inserted_at,
+				era_id,
+				version_label
+			)
 			SELECT contract_id, creator_address, wasm_hash, created_ledger,
 			       created_at, inserted_at, era_id, version_label
 			FROM postgres_scan('%s', 'public', '%s')

--- a/obsrvr-lake/silver-cold-flusher/go/silver_schema.go
+++ b/obsrvr-lake/silver-cold-flusher/go/silver_schema.go
@@ -117,6 +117,62 @@ func (c *DuckDBClient) applySilverMigrations() error {
 				c.config.CatalogName, c.config.SchemaName,
 			),
 		},
+		{
+			name: "contract_invocations_raw.era_id",
+			sql: fmt.Sprintf(
+				`ALTER TABLE %s.%s.contract_invocations_raw ADD COLUMN IF NOT EXISTS era_id VARCHAR`,
+				c.config.CatalogName, c.config.SchemaName,
+			),
+		},
+		{
+			name: "contract_invocations_raw.version_label",
+			sql: fmt.Sprintf(
+				`ALTER TABLE %s.%s.contract_invocations_raw ADD COLUMN IF NOT EXISTS version_label VARCHAR`,
+				c.config.CatalogName, c.config.SchemaName,
+			),
+		},
+		{
+			name: "contract_metadata.era_id",
+			sql: fmt.Sprintf(
+				`ALTER TABLE %s.%s.contract_metadata ADD COLUMN IF NOT EXISTS era_id VARCHAR`,
+				c.config.CatalogName, c.config.SchemaName,
+			),
+		},
+		{
+			name: "contract_metadata.version_label",
+			sql: fmt.Sprintf(
+				`ALTER TABLE %s.%s.contract_metadata ADD COLUMN IF NOT EXISTS version_label VARCHAR`,
+				c.config.CatalogName, c.config.SchemaName,
+			),
+		},
+		{
+			name: "trustlines_current.era_id",
+			sql: fmt.Sprintf(
+				`ALTER TABLE %s.%s.trustlines_current ADD COLUMN IF NOT EXISTS era_id VARCHAR`,
+				c.config.CatalogName, c.config.SchemaName,
+			),
+		},
+		{
+			name: "trustlines_current.version_label",
+			sql: fmt.Sprintf(
+				`ALTER TABLE %s.%s.trustlines_current ADD COLUMN IF NOT EXISTS version_label VARCHAR`,
+				c.config.CatalogName, c.config.SchemaName,
+			),
+		},
+		{
+			name: "offers_current.era_id",
+			sql: fmt.Sprintf(
+				`ALTER TABLE %s.%s.offers_current ADD COLUMN IF NOT EXISTS era_id VARCHAR`,
+				c.config.CatalogName, c.config.SchemaName,
+			),
+		},
+		{
+			name: "offers_current.version_label",
+			sql: fmt.Sprintf(
+				`ALTER TABLE %s.%s.offers_current ADD COLUMN IF NOT EXISTS version_label VARCHAR`,
+				c.config.CatalogName, c.config.SchemaName,
+			),
+		},
 	}
 
 	for _, m := range migrations {

--- a/obsrvr-lake/silver-cold-flusher/schema/silver_schema.sql
+++ b/obsrvr-lake/silver-cold-flusher/schema/silver_schema.sql
@@ -354,6 +354,8 @@ CREATE TABLE IF NOT EXISTS testnet_catalog.silver.offers_current (
     created_at TIMESTAMP,
     sponsor VARCHAR,
     ledger_range BIGINT,
+    era_id VARCHAR,
+    version_label VARCHAR,
     inserted_at TIMESTAMP,
     updated_at TIMESTAMP
 );
@@ -413,6 +415,8 @@ CREATE TABLE IF NOT EXISTS testnet_catalog.silver.trustlines_current (
     created_at TIMESTAMP,
     sponsor VARCHAR,
     ledger_range BIGINT,
+    era_id VARCHAR,
+    version_label VARCHAR,
     inserted_at TIMESTAMP,
     updated_at TIMESTAMP
 );

--- a/obsrvr-lake/silver-realtime-transformer/go/bronze_cold_reader.go
+++ b/obsrvr-lake/silver-realtime-transformer/go/bronze_cold_reader.go
@@ -530,8 +530,8 @@ func (r *BronzeColdReader) QueryAccountsSnapshot(ctx context.Context, startLedge
 				closed_at AS updated_at,
 				ledger_sequence,
 				ledger_range,
-				NULL AS era_id,
-				NULL AS version_label,
+				era_id,
+				version_label,
 				ROW_NUMBER() OVER (PARTITION BY account_id ORDER BY ledger_sequence DESC) as rn
 			FROM %s
 			WHERE ledger_sequence BETWEEN $1 AND $2
@@ -601,8 +601,8 @@ func (r *BronzeColdReader) QueryAccountsSnapshotAll(ctx context.Context, startLe
 			closed_at AS created_at,
 			closed_at AS updated_at,
 			ledger_range,
-			NULL AS era_id,
-			NULL AS version_label
+			era_id,
+			version_label
 		FROM %s
 		WHERE ledger_sequence BETWEEN $1 AND $2
 		ORDER BY account_id, ledger_sequence
@@ -635,8 +635,8 @@ func (r *BronzeColdReader) QueryTrustlinesSnapshotAll(ctx context.Context, start
 			l.closed_at,
 			l.closed_at AS created_at,
 			t.ledger_range,
-			NULL AS era_id,
-			NULL AS version_label
+			t.era_id,
+			t.version_label
 		FROM %s t
 		INNER JOIN %s l ON t.ledger_sequence = l.sequence
 		WHERE t.ledger_sequence BETWEEN $1 AND $2
@@ -670,6 +670,8 @@ func (r *BronzeColdReader) QueryTrustlinesSnapshot(ctx context.Context, startLed
 				ledger_sequence,
 				TIMESTAMP '1970-01-01' AS created_at,
 				ledger_range,
+				era_id,
+				version_label,
 				ROW_NUMBER() OVER (PARTITION BY account_id, asset_type, asset_code, asset_issuer ORDER BY ledger_sequence DESC) as rn
 			FROM %s
 			WHERE ledger_sequence BETWEEN $1 AND $2
@@ -688,7 +690,9 @@ func (r *BronzeColdReader) QueryTrustlinesSnapshot(ctx context.Context, startLed
 			clawback_enabled,
 			ledger_sequence,
 			created_at,
-			ledger_range
+			ledger_range,
+			era_id,
+			version_label
 		FROM ranked
 		WHERE rn = 1
 	`, r.tableName("trustlines_snapshot_v1"))
@@ -720,6 +724,8 @@ func (r *BronzeColdReader) QueryOffersSnapshot(ctx context.Context, startLedger,
 				ledger_sequence,
 				closed_at AS created_at,
 				ledger_range,
+				era_id,
+				version_label,
 				ROW_NUMBER() OVER (PARTITION BY offer_id ORDER BY ledger_sequence DESC) as rn
 			FROM %s
 			WHERE ledger_sequence BETWEEN $1 AND $2
@@ -738,7 +744,9 @@ func (r *BronzeColdReader) QueryOffersSnapshot(ctx context.Context, startLedger,
 			flags,
 			ledger_sequence,
 			created_at,
-			ledger_range
+			ledger_range,
+			era_id,
+			version_label
 		FROM ranked
 		WHERE rn = 1
 	`, r.tableName("offers_snapshot_v1"))
@@ -770,8 +778,8 @@ func (r *BronzeColdReader) QueryOffersSnapshotAll(ctx context.Context, startLedg
 			flags,
 			closed_at AS created_at,
 			ledger_range,
-			NULL AS era_id,
-			NULL AS version_label
+			era_id,
+			version_label
 		FROM %s
 		WHERE ledger_sequence BETWEEN $1 AND $2
 		ORDER BY offer_id, ledger_sequence
@@ -796,8 +804,8 @@ func (r *BronzeColdReader) QueryAccountSignersSnapshotAll(ctx context.Context, s
 			weight,
 			sponsor,
 			ledger_range,
-			NULL AS era_id,
-			NULL AS version_label
+			era_id,
+			version_label
 		FROM %s
 		WHERE ledger_sequence BETWEEN $1 AND $2
 		  AND deleted = false
@@ -830,7 +838,9 @@ func (r *BronzeColdReader) QueryContractInvocations(ctx context.Context, startLe
 			o.soroban_arguments_json,
 			o.transaction_successful,
 			o.created_at,
-			o.ledger_range
+			o.ledger_range,
+			o.era_id,
+			o.version_label
 		FROM %s o
 		WHERE o.ledger_sequence BETWEEN $1 AND $2
 		  AND o.type = 24

--- a/obsrvr-lake/silver-realtime-transformer/go/bronze_reader.go
+++ b/obsrvr-lake/silver-realtime-transformer/go/bronze_reader.go
@@ -662,7 +662,9 @@ func (br *BronzeReader) QueryTrustlinesSnapshot(ctx context.Context, startLedger
 			clawback_enabled,
 			ledger_sequence,
 			created_at,
-			ledger_range
+			ledger_range,
+			era_id,
+			version_label
 		FROM trustlines_snapshot_v1
 		WHERE ledger_sequence BETWEEN $1 AND $2
 		ORDER BY account_id, asset_type, asset_code, asset_issuer, ledger_sequence DESC
@@ -694,7 +696,9 @@ func (br *BronzeReader) QueryOffersSnapshot(ctx context.Context, startLedger, en
 			flags,
 			ledger_sequence,
 			created_at,
-			ledger_range
+			ledger_range,
+			era_id,
+			version_label
 		FROM offers_snapshot_v1
 		WHERE ledger_sequence BETWEEN $1 AND $2
 		ORDER BY offer_id, ledger_sequence DESC
@@ -786,7 +790,9 @@ func (br *BronzeReader) QueryContractInvocations(ctx context.Context, startLedge
 			o.soroban_arguments_json,
 			o.transaction_successful,
 			o.created_at,
-			o.ledger_range
+			o.ledger_range,
+			o.era_id,
+			o.version_label
 		FROM operations_row_v2 o
 		WHERE o.ledger_sequence BETWEEN $1 AND $2
 		  AND o.type = 24  -- InvokeHostFunction
@@ -1268,7 +1274,9 @@ func (br *BronzeReader) QueryContractCreations(ctx context.Context, startLedger,
 			creator_address,
 			wasm_hash,
 			created_ledger,
-			created_at
+			created_at,
+			era_id,
+			version_label
 		FROM contract_creations_v1
 		WHERE created_ledger BETWEEN $1 AND $2
 		ORDER BY created_ledger

--- a/obsrvr-lake/silver-realtime-transformer/go/schema/init_silver_hot_complete.sql
+++ b/obsrvr-lake/silver-realtime-transformer/go/schema/init_silver_hot_complete.sql
@@ -304,6 +304,8 @@ CREATE TABLE IF NOT EXISTS trustlines_current (
     created_at TIMESTAMP,
     sponsor VARCHAR(56),
     ledger_range BIGINT,
+    era_id TEXT,
+    version_label TEXT,
 
     -- Metadata
     inserted_at TIMESTAMP DEFAULT NOW(),
@@ -345,6 +347,8 @@ CREATE TABLE IF NOT EXISTS offers_current (
     created_at TIMESTAMP,
     sponsor VARCHAR(56),
     ledger_range BIGINT,
+    era_id TEXT,
+    version_label TEXT,
 
     -- Metadata
     inserted_at TIMESTAMP DEFAULT NOW(),
@@ -755,6 +759,10 @@ CREATE TABLE IF NOT EXISTS contract_invocations_raw (
     -- Partitioning
     ledger_range BIGINT NOT NULL,
 
+    -- Versioning metadata
+    era_id TEXT,
+    version_label TEXT,
+
     -- Metadata
     inserted_at TIMESTAMP DEFAULT NOW(),
 
@@ -777,7 +785,9 @@ CREATE TABLE IF NOT EXISTS contract_metadata (
     wasm_hash TEXT,
     created_ledger BIGINT NOT NULL,
     created_at TIMESTAMP NOT NULL,
-    inserted_at TIMESTAMP DEFAULT NOW()
+    inserted_at TIMESTAMP DEFAULT NOW(),
+    era_id TEXT,
+    version_label TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_contract_metadata_creator ON contract_metadata(creator_address);

--- a/obsrvr-lake/silver-realtime-transformer/go/schema/init_silver_hot_complete.sql
+++ b/obsrvr-lake/silver-realtime-transformer/go/schema/init_silver_hot_complete.sql
@@ -326,6 +326,10 @@ CREATE INDEX IF NOT EXISTS idx_trustlines_account ON trustlines_current(account_
 CREATE INDEX IF NOT EXISTS idx_trustlines_asset ON trustlines_current(asset_code, asset_issuer);
 CREATE INDEX IF NOT EXISTS idx_trustlines_last_modified ON trustlines_current(last_modified_ledger DESC);
 
+-- Upgrade existing deployments created before versioning metadata existed
+ALTER TABLE IF EXISTS trustlines_current ADD COLUMN IF NOT EXISTS era_id TEXT;
+ALTER TABLE IF EXISTS trustlines_current ADD COLUMN IF NOT EXISTS version_label TEXT;
+
 -- Table: offers_current
 -- Current state of all offers
 CREATE TABLE IF NOT EXISTS offers_current (
@@ -359,6 +363,10 @@ CREATE INDEX IF NOT EXISTS idx_offers_seller ON offers_current(seller_id);
 CREATE INDEX IF NOT EXISTS idx_offers_selling_asset ON offers_current(selling_asset_code, selling_asset_issuer);
 CREATE INDEX IF NOT EXISTS idx_offers_buying_asset ON offers_current(buying_asset_code, buying_asset_issuer);
 CREATE INDEX IF NOT EXISTS idx_offers_last_modified ON offers_current(last_modified_ledger DESC);
+
+-- Upgrade existing deployments created before versioning metadata existed
+ALTER TABLE IF EXISTS offers_current ADD COLUMN IF NOT EXISTS era_id TEXT;
+ALTER TABLE IF EXISTS offers_current ADD COLUMN IF NOT EXISTS version_label TEXT;
 
 -- Table: claimable_balances_current
 -- Current state of claimable balances
@@ -777,6 +785,10 @@ CREATE INDEX IF NOT EXISTS idx_contract_invocations_ledger_range ON contract_inv
 CREATE INDEX IF NOT EXISTS idx_contract_invocations_closed_at ON contract_invocations_raw(closed_at DESC);
 CREATE INDEX IF NOT EXISTS idx_contract_invocations_contract_function ON contract_invocations_raw(contract_id, function_name);
 
+-- Upgrade existing deployments created before versioning metadata existed
+ALTER TABLE IF EXISTS contract_invocations_raw ADD COLUMN IF NOT EXISTS era_id TEXT;
+ALTER TABLE IF EXISTS contract_invocations_raw ADD COLUMN IF NOT EXISTS version_label TEXT;
+
 -- Table: contract_metadata
 -- Contract creation metadata (creator, wasm hash, creation time)
 CREATE TABLE IF NOT EXISTS contract_metadata (
@@ -792,6 +804,10 @@ CREATE TABLE IF NOT EXISTS contract_metadata (
 
 CREATE INDEX IF NOT EXISTS idx_contract_metadata_creator ON contract_metadata(creator_address);
 CREATE INDEX IF NOT EXISTS idx_contract_metadata_wasm ON contract_metadata(wasm_hash) WHERE wasm_hash IS NOT NULL;
+
+-- Upgrade existing deployments created before versioning metadata existed
+ALTER TABLE IF EXISTS contract_metadata ADD COLUMN IF NOT EXISTS era_id TEXT;
+ALTER TABLE IF EXISTS contract_metadata ADD COLUMN IF NOT EXISTS version_label TEXT;
 
 -- ============================================================================
 -- SEMANTIC LAYER TABLES

--- a/obsrvr-lake/silver-realtime-transformer/go/silver_writer.go
+++ b/obsrvr-lake/silver-realtime-transformer/go/silver_writer.go
@@ -314,14 +314,15 @@ func (sw *SilverWriter) WriteTrustlineCurrent(ctx context.Context, tx *sql.Tx, r
 		INSERT INTO trustlines_current (
 			account_id, asset_type, asset_issuer, asset_code, liquidity_pool_id,
 			balance, trust_line_limit, buying_liabilities, selling_liabilities,
-			flags, last_modified_ledger, ledger_sequence, created_at, sponsor, ledger_range
+			flags, last_modified_ledger, ledger_sequence, created_at, sponsor, ledger_range,
+			era_id, version_label
 		) VALUES (
 			$1, $2, $3, $4, $5,
 			ROUND($6::NUMERIC * 10000000)::BIGINT,
 			ROUND($7::NUMERIC * 10000000)::BIGINT,
 			ROUND($8::NUMERIC * 10000000)::BIGINT,
 			ROUND($9::NUMERIC * 10000000)::BIGINT,
-			$10, $11, $12, $13, $14, $15
+			$10, $11, $12, $13, $14, $15, $16, $17
 		)
 		ON CONFLICT (account_id, asset_type, COALESCE(asset_code, ''), COALESCE(asset_issuer, ''), COALESCE(liquidity_pool_id, '')) DO UPDATE SET
 			balance = EXCLUDED.balance,
@@ -333,6 +334,8 @@ func (sw *SilverWriter) WriteTrustlineCurrent(ctx context.Context, tx *sql.Tx, r
 			ledger_sequence = EXCLUDED.ledger_sequence,
 			sponsor = EXCLUDED.sponsor,
 			ledger_range = EXCLUDED.ledger_range,
+			era_id = EXCLUDED.era_id,
+			version_label = EXCLUDED.version_label,
 			updated_at = NOW()
 	`
 
@@ -340,6 +343,7 @@ func (sw *SilverWriter) WriteTrustlineCurrent(ctx context.Context, tx *sql.Tx, r
 		row.AccountID, row.AssetType, row.AssetIssuer, row.AssetCode, row.LiquidityPoolID,
 		row.Balance, row.TrustLineLimit, row.BuyingLiabilities, row.SellingLiabilities,
 		row.Flags, row.LastModifiedLedger, row.LedgerSequence, row.CreatedAt, row.Sponsor, row.LedgerRange,
+		row.EraID, row.VersionLabel,
 	)
 
 	if err != nil {
@@ -356,11 +360,12 @@ func (sw *SilverWriter) WriteOfferCurrent(ctx context.Context, tx *sql.Tx, row *
 			offer_id, seller_id, selling_asset_type, selling_asset_code, selling_asset_issuer,
 			buying_asset_type, buying_asset_code, buying_asset_issuer,
 			amount, price_n, price_d, price, flags,
-			last_modified_ledger, ledger_sequence, created_at, sponsor, ledger_range
+			last_modified_ledger, ledger_sequence, created_at, sponsor, ledger_range,
+			era_id, version_label
 		) VALUES (
 			$1, $2, $3, $4, $5, $6, $7, $8,
 			$9::BIGINT, $10, $11, $12::DECIMAL, $13,
-			$14, $15, $16, $17, $18
+			$14, $15, $16, $17, $18, $19, $20
 		)
 		ON CONFLICT (offer_id) DO UPDATE SET
 			seller_id = EXCLUDED.seller_id,
@@ -379,6 +384,8 @@ func (sw *SilverWriter) WriteOfferCurrent(ctx context.Context, tx *sql.Tx, row *
 			ledger_sequence = EXCLUDED.ledger_sequence,
 			sponsor = EXCLUDED.sponsor,
 			ledger_range = EXCLUDED.ledger_range,
+			era_id = EXCLUDED.era_id,
+			version_label = EXCLUDED.version_label,
 			updated_at = NOW()
 	`
 
@@ -387,6 +394,7 @@ func (sw *SilverWriter) WriteOfferCurrent(ctx context.Context, tx *sql.Tx, row *
 		row.BuyingAssetType, row.BuyingAssetCode, row.BuyingAssetIssuer,
 		row.Amount, row.PriceN, row.PriceD, row.Price, row.Flags,
 		row.LastModifiedLedger, row.LedgerSequence, row.CreatedAt, row.Sponsor, row.LedgerRange,
+		row.EraID, row.VersionLabel,
 	)
 
 	if err != nil {
@@ -693,19 +701,21 @@ func (sw *SilverWriter) UpdateAccountSignerSnapshotValidTo(ctx context.Context, 
 }
 
 // WriteContractMetadata upserts a contract metadata row
-func (sw *SilverWriter) WriteContractMetadata(ctx context.Context, tx *sql.Tx, contractID, creatorAddress string, wasmHash *string, createdLedger int64, createdAt interface{}) error {
+func (sw *SilverWriter) WriteContractMetadata(ctx context.Context, tx *sql.Tx, contractID, creatorAddress string, wasmHash *string, createdLedger int64, createdAt interface{}, eraID, versionLabel interface{}) error {
 	query := `
 		INSERT INTO contract_metadata (
-			contract_id, creator_address, wasm_hash, created_ledger, created_at
-		) VALUES ($1, $2, $3, $4, $5)
+			contract_id, creator_address, wasm_hash, created_ledger, created_at, era_id, version_label
+		) VALUES ($1, $2, $3, $4, $5, $6, $7)
 		ON CONFLICT (contract_id) DO UPDATE SET
 			creator_address = EXCLUDED.creator_address,
 			wasm_hash = COALESCE(EXCLUDED.wasm_hash, contract_metadata.wasm_hash),
 			created_ledger = EXCLUDED.created_ledger,
-			created_at = EXCLUDED.created_at
+			created_at = EXCLUDED.created_at,
+			era_id = EXCLUDED.era_id,
+			version_label = EXCLUDED.version_label
 	`
 
-	_, err := tx.ExecContext(ctx, query, contractID, creatorAddress, wasmHash, createdLedger, createdAt)
+	_, err := tx.ExecContext(ctx, query, contractID, creatorAddress, wasmHash, createdLedger, createdAt, eraID, versionLabel)
 	if err != nil {
 		return fmt.Errorf("failed to write contract metadata: %w", err)
 	}
@@ -727,15 +737,19 @@ func (sw *SilverWriter) WriteContractInvocation(ctx context.Context, tx *sql.Tx,
 			arguments_json,
 			successful,
 			closed_at,
-			ledger_range
+			ledger_range,
+			era_id,
+			version_label
 		) VALUES (
-			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
+			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13
 		)
 		ON CONFLICT (ledger_sequence, transaction_index, operation_index) DO UPDATE SET
 			contract_id = EXCLUDED.contract_id,
 			function_name = EXCLUDED.function_name,
 			arguments_json = EXCLUDED.arguments_json,
-			successful = EXCLUDED.successful
+			successful = EXCLUDED.successful,
+			era_id = EXCLUDED.era_id,
+			version_label = EXCLUDED.version_label
 	`
 
 	_, err := tx.ExecContext(ctx, query,
@@ -750,6 +764,8 @@ func (sw *SilverWriter) WriteContractInvocation(ctx context.Context, tx *sql.Tx,
 		row.Successful,
 		row.ClosedAt,
 		row.LedgerRange,
+		row.EraID,
+		row.VersionLabel,
 	)
 
 	if err != nil {

--- a/obsrvr-lake/silver-realtime-transformer/go/silver_writer_batch.go
+++ b/obsrvr-lake/silver-realtime-transformer/go/silver_writer_batch.go
@@ -294,7 +294,7 @@ const accountCurrentConflict = `ON CONFLICT (account_id) DO UPDATE SET
 var trustlineCurrentColumns = []string{
 	"account_id", "asset_type", "asset_issuer", "asset_code", "liquidity_pool_id",
 	"balance", "trust_line_limit", "buying_liabilities", "selling_liabilities",
-	"flags", "last_modified_ledger", "ledger_sequence", "created_at", "sponsor", "ledger_range",
+	"flags", "last_modified_ledger", "ledger_sequence", "created_at", "sponsor", "ledger_range", "era_id", "version_label",
 }
 
 const trustlineCurrentConflict = `ON CONFLICT (account_id, asset_type, COALESCE(asset_code, ''), COALESCE(asset_issuer, ''), COALESCE(liquidity_pool_id, '')) DO UPDATE SET
@@ -307,13 +307,15 @@ const trustlineCurrentConflict = `ON CONFLICT (account_id, asset_type, COALESCE(
 	ledger_sequence = EXCLUDED.ledger_sequence,
 	sponsor = EXCLUDED.sponsor,
 	ledger_range = EXCLUDED.ledger_range,
+	era_id = EXCLUDED.era_id,
+	version_label = EXCLUDED.version_label,
 	updated_at = NOW()`
 
 var offerCurrentColumns = []string{
 	"offer_id", "seller_id", "selling_asset_type", "selling_asset_code", "selling_asset_issuer",
 	"buying_asset_type", "buying_asset_code", "buying_asset_issuer",
 	"amount", "price_n", "price_d", "price", "flags",
-	"last_modified_ledger", "ledger_sequence", "created_at", "sponsor", "ledger_range",
+	"last_modified_ledger", "ledger_sequence", "created_at", "sponsor", "ledger_range", "era_id", "version_label",
 }
 
 const offerCurrentConflict = `ON CONFLICT (offer_id) DO UPDATE SET
@@ -333,29 +335,35 @@ const offerCurrentConflict = `ON CONFLICT (offer_id) DO UPDATE SET
 	ledger_sequence = EXCLUDED.ledger_sequence,
 	sponsor = EXCLUDED.sponsor,
 	ledger_range = EXCLUDED.ledger_range,
+	era_id = EXCLUDED.era_id,
+	version_label = EXCLUDED.version_label,
 	updated_at = NOW()`
 
 var contractInvocationColumns = []string{
 	"ledger_sequence", "transaction_index", "operation_index",
 	"transaction_hash", "source_account", "contract_id", "function_name",
-	"arguments_json", "successful", "closed_at", "ledger_range",
+	"arguments_json", "successful", "closed_at", "ledger_range", "era_id", "version_label",
 }
 
 const contractInvocationConflict = `ON CONFLICT (ledger_sequence, transaction_index, operation_index) DO UPDATE SET
 	contract_id = EXCLUDED.contract_id,
 	function_name = EXCLUDED.function_name,
 	arguments_json = EXCLUDED.arguments_json,
-	successful = EXCLUDED.successful`
+	successful = EXCLUDED.successful,
+	era_id = EXCLUDED.era_id,
+	version_label = EXCLUDED.version_label`
 
 var contractMetadataColumns = []string{
-	"contract_id", "creator_address", "wasm_hash", "created_ledger", "created_at",
+	"contract_id", "creator_address", "wasm_hash", "created_ledger", "created_at", "era_id", "version_label",
 }
 
 const contractMetadataConflict = `ON CONFLICT (contract_id) DO UPDATE SET
 	creator_address = EXCLUDED.creator_address,
 	wasm_hash = COALESCE(EXCLUDED.wasm_hash, contract_metadata.wasm_hash),
 	created_ledger = EXCLUDED.created_ledger,
-	created_at = EXCLUDED.created_at`
+	created_at = EXCLUDED.created_at,
+	era_id = EXCLUDED.era_id,
+	version_label = EXCLUDED.version_label`
 
 var liquidityPoolCurrentColumns = []string{
 	"liquidity_pool_id", "pool_type", "fee", "trustline_count", "total_pool_shares",

--- a/obsrvr-lake/silver-realtime-transformer/go/transformer.go
+++ b/obsrvr-lake/silver-realtime-transformer/go/transformer.go
@@ -1468,7 +1468,7 @@ func (rt *RealtimeTransformer) transformTrustlinesCurrent(ctx context.Context, t
 			&row.AccountID, &row.AssetType, &row.AssetIssuer, &row.AssetCode,
 			&row.Balance, &row.TrustLineLimit, &row.BuyingLiabilities, &row.SellingLiabilities,
 			&row.Authorized, &row.AuthorizedToMaintainLiabilities, &row.ClawbackEnabled,
-			&row.LedgerSequence, &row.CreatedAt, &row.LedgerRange,
+			&row.LedgerSequence, &row.CreatedAt, &row.LedgerRange, &row.EraID, &row.VersionLabel,
 		)
 
 		if err != nil {
@@ -1534,7 +1534,7 @@ func (rt *RealtimeTransformer) transformOffersCurrent(ctx context.Context, tx *s
 			&row.OfferID, &row.SellerID, &row.SellingAssetType, &row.SellingAssetCode, &row.SellingAssetIssuer,
 			&row.BuyingAssetType, &row.BuyingAssetCode, &row.BuyingAssetIssuer,
 			&row.Amount, &row.Price, &row.Flags,
-			&row.LedgerSequence, &row.CreatedAt, &row.LedgerRange,
+			&row.LedgerSequence, &row.CreatedAt, &row.LedgerRange, &row.EraID, &row.VersionLabel,
 		)
 
 		if err != nil {
@@ -1858,6 +1858,7 @@ func (rt *RealtimeTransformer) transformContractInvocations(ctx context.Context,
 			&row.LedgerSequence, &row.TransactionIndex, &row.OperationIndex,
 			&row.TransactionHash, &row.SourceAccount, &row.ContractID, &row.FunctionName,
 			&row.ArgumentsJSON, &row.Successful, &row.ClosedAt, &row.LedgerRange,
+			&row.EraID, &row.VersionLabel,
 		)
 		if err != nil {
 			return count, fmt.Errorf("failed to scan contract invocation row: %w", err)
@@ -1897,8 +1898,10 @@ func (rt *RealtimeTransformer) transformContractMetadata(ctx context.Context, tx
 			wasmHash       sql.NullString
 			createdLedger  int64
 			createdAt      time.Time
+			eraID          sql.NullString
+			versionLabel   sql.NullString
 		)
-		if err := rows.Scan(&contractID, &creatorAddress, &wasmHash, &createdLedger, &createdAt); err != nil {
+		if err := rows.Scan(&contractID, &creatorAddress, &wasmHash, &createdLedger, &createdAt, &eraID, &versionLabel); err != nil {
 			return count, fmt.Errorf("failed to scan contract creation row: %w", err)
 		}
 
@@ -1907,7 +1910,7 @@ func (rt *RealtimeTransformer) transformContractMetadata(ctx context.Context, tx
 			wasmHashPtr = &wasmHash.String
 		}
 
-		if err := batch.Add(contractID, creatorAddress, wasmHashPtr, createdLedger, createdAt); err != nil {
+		if err := batch.Add(contractID, creatorAddress, wasmHashPtr, createdLedger, createdAt, eraID, versionLabel); err != nil {
 			return count, fmt.Errorf("failed to add contract metadata to batch: %w", err)
 		}
 		if err := batch.FlushIfNeeded(ctx, tx); err != nil {

--- a/obsrvr-lake/silver-realtime-transformer/go/types.go
+++ b/obsrvr-lake/silver-realtime-transformer/go/types.go
@@ -13,17 +13,17 @@ import (
 // EnrichedOperationRow represents a row in the enriched_history_operations table
 type EnrichedOperationRow struct {
 	// Operation fields
-	TransactionHash      *string
-	OperationIndex       *int
-	LedgerSequence       *int64
-	SourceAccount        *string
-	Type                 *int
-	TypeString           *string
-	CreatedAt            *time.Time
+	TransactionHash       *string
+	OperationIndex        *int
+	LedgerSequence        *int64
+	SourceAccount         *string
+	Type                  *int
+	TypeString            *string
+	CreatedAt             *time.Time
 	TransactionSuccessful *bool
-	OperationResultCode  *string
-	OperationTraceCode   *string
-	LedgerRange          *int64
+	OperationResultCode   *string
+	OperationTraceCode    *string
+	LedgerRange           *int64
 
 	// Asset fields
 	SourceAccountMuxed *string
@@ -69,14 +69,14 @@ type EnrichedOperationRow struct {
 	InflationDest   *string
 
 	// Flags and thresholds
-	SetFlags       *int
-	SetFlagsS      interface{} // PostgreSQL array
-	ClearFlags     *int
-	ClearFlagsS    interface{} // PostgreSQL array
+	SetFlags        *int
+	SetFlagsS       interface{} // PostgreSQL array
+	ClearFlags      *int
+	ClearFlagsS     interface{} // PostgreSQL array
 	MasterKeyWeight *int
-	LowThreshold   *int
-	MedThreshold   *int
-	HighThreshold  *int
+	LowThreshold    *int
+	MedThreshold    *int
+	HighThreshold   *int
 
 	// Signer fields
 	SignerAccountID *string
@@ -95,10 +95,10 @@ type EnrichedOperationRow struct {
 	FunctionName     *string
 
 	// Claimable balance fields
-	BalanceID      *string
-	Claimant       *string
-	ClaimantMuxed  *string
-	Predicate      *string
+	BalanceID     *string
+	Claimant      *string
+	ClaimantMuxed *string
+	Predicate     *string
 
 	// Liquidity pool fields
 	LiquidityPoolID *string
@@ -127,15 +127,15 @@ type EnrichedOperationRow struct {
 	TxMemo           *string
 
 	// Ledger fields (enriched)
-	LedgerClosedAt           *time.Time
-	LedgerTotalCoins         *int64
-	LedgerFeePool            *int64
-	LedgerBaseFee            *int
-	LedgerBaseReserve        *int
-	LedgerTransactionCount   *int
-	LedgerOperationCount     *int
-	LedgerSuccessfulTxCount  *int
-	LedgerFailedTxCount      *int
+	LedgerClosedAt          *time.Time
+	LedgerTotalCoins        *int64
+	LedgerFeePool           *int64
+	LedgerBaseFee           *int
+	LedgerBaseReserve       *int
+	LedgerTransactionCount  *int
+	LedgerOperationCount    *int
+	LedgerSuccessfulTxCount *int
+	LedgerFailedTxCount     *int
 
 	// Derived fields
 	IsPaymentOp *bool
@@ -254,21 +254,23 @@ type TrustlineSnapshotRow struct {
 
 // TrustlineCurrentRow represents a row in the trustlines_current table
 type TrustlineCurrentRow struct {
-	AccountID                       string
-	AssetType                       string
-	AssetIssuer                     string
-	AssetCode                       string
-	LiquidityPoolID                 sql.NullString // NULL for classic trustlines
-	Balance                         string         // stored as TEXT in bronze, converted to BIGINT for silver
-	TrustLineLimit                  string
-	BuyingLiabilities               string
-	SellingLiabilities              string
-	Flags                           int // Computed from: authorized(1) + auth_to_maintain(2) + clawback(4)
-	LastModifiedLedger              int64
-	LedgerSequence                  int64
-	CreatedAt                       time.Time
-	Sponsor                         sql.NullString
-	LedgerRange                     int64
+	AccountID          string
+	AssetType          string
+	AssetIssuer        string
+	AssetCode          string
+	LiquidityPoolID    sql.NullString // NULL for classic trustlines
+	Balance            string         // stored as TEXT in bronze, converted to BIGINT for silver
+	TrustLineLimit     string
+	BuyingLiabilities  string
+	SellingLiabilities string
+	Flags              int // Computed from: authorized(1) + auth_to_maintain(2) + clawback(4)
+	LastModifiedLedger int64
+	LedgerSequence     int64
+	CreatedAt          time.Time
+	Sponsor            sql.NullString
+	LedgerRange        int64
+	EraID              sql.NullString
+	VersionLabel       sql.NullString
 
 	// Temporary fields for bronze parsing (not written to silver)
 	Authorized                      bool
@@ -317,6 +319,8 @@ type OfferCurrentRow struct {
 	CreatedAt          time.Time
 	Sponsor            sql.NullString
 	LedgerRange        int64
+	EraID              sql.NullString
+	VersionLabel       sql.NullString
 }
 
 // AccountSignerSnapshotRow represents a row in the account_signers_snapshot table (SCD Type 2)
@@ -359,7 +363,9 @@ type ContractInvocationRow struct {
 	ClosedAt   time.Time
 
 	// Partitioning
-	LedgerRange int64
+	LedgerRange  int64
+	EraID        sql.NullString
+	VersionLabel sql.NullString
 }
 
 // ContractCallRow represents a row in the contract_invocation_calls table
@@ -375,10 +381,10 @@ type ContractCallRow struct {
 	TransactionHash  string
 
 	// Call relationship
-	FromContract string
-	ToContract   string
-	FunctionName string
-	CallDepth    int
+	FromContract   string
+	ToContract     string
+	FunctionName   string
+	CallDepth      int
 	ExecutionOrder int
 
 	// Status
@@ -407,24 +413,24 @@ type ContractHierarchyRow struct {
 
 // LiquidityPoolCurrentRow represents a row in the liquidity_pools_current table
 type LiquidityPoolCurrentRow struct {
-	LiquidityPoolID   string
-	PoolType          string
-	Fee               int
-	TrustlineCount    int
-	TotalPoolShares   int64
-	AssetAType        string
-	AssetACode        sql.NullString
-	AssetAIssuer      sql.NullString
-	AssetAAmount      int64
-	AssetBType        string
-	AssetBCode        sql.NullString
-	AssetBIssuer      sql.NullString
-	AssetBAmount      int64
+	LiquidityPoolID    string
+	PoolType           string
+	Fee                int
+	TrustlineCount     int
+	TotalPoolShares    int64
+	AssetAType         string
+	AssetACode         sql.NullString
+	AssetAIssuer       sql.NullString
+	AssetAAmount       int64
+	AssetBType         string
+	AssetBCode         sql.NullString
+	AssetBIssuer       sql.NullString
+	AssetBAmount       int64
 	LastModifiedLedger int64
-	LedgerSequence    int64
-	ClosedAt          time.Time
-	CreatedAt         time.Time
-	LedgerRange       int64
+	LedgerSequence     int64
+	ClosedAt           time.Time
+	CreatedAt          time.Time
+	LedgerRange        int64
 }
 
 // ClaimableBalanceCurrentRow represents a row in the claimable_balances_current table
@@ -555,15 +561,15 @@ type ContractCodeCurrentRow struct {
 // TTLCurrentRow represents a row in the ttl_current table
 // Extracted from Bronze ttl_snapshot_v1 (UPSERT pattern)
 type TTLCurrentRow struct {
-	KeyHash             string
-	LiveUntilLedgerSeq  int64
-	TTLRemaining        sql.NullInt32 // Computed: live_until_ledger_seq - ledger_sequence
-	Expired             bool
-	LastModifiedLedger  int64
-	LedgerSequence      int64
-	ClosedAt            time.Time
-	CreatedAt           time.Time
-	LedgerRange         int64
+	KeyHash            string
+	LiveUntilLedgerSeq int64
+	TTLRemaining       sql.NullInt32 // Computed: live_until_ledger_seq - ledger_sequence
+	Expired            bool
+	LastModifiedLedger int64
+	LedgerSequence     int64
+	ClosedAt           time.Time
+	CreatedAt          time.Time
+	LedgerRange        int64
 }
 
 // EvictedKeyRow represents a row in the evicted_keys table (event stream - append only)
@@ -595,14 +601,14 @@ type RestoredKeyRow struct {
 // TokenRegistryRow represents a row in the token_registry table
 // Materialized from Bronze contract_data_snapshot_v1 instance entries with token metadata
 type TokenRegistryRow struct {
-	ContractID        string
-	TokenName         sql.NullString
-	TokenSymbol       sql.NullString
-	TokenDecimals     int
-	AssetCode         sql.NullString
-	AssetIssuer       sql.NullString
-	TokenType         string // "sac" or "custom_soroban"
-	FirstSeenLedger   int64
+	ContractID         string
+	TokenName          sql.NullString
+	TokenSymbol        sql.NullString
+	TokenDecimals      int
+	AssetCode          sql.NullString
+	AssetIssuer        sql.NullString
+	TokenType          string // "sac" or "custom_soroban"
+	FirstSeenLedger    int64
 	LastModifiedLedger int64
 }
 
@@ -762,6 +768,7 @@ func (row *TrustlineCurrentRow) TrustlineCurrentValues() ([]interface{}, error) 
 		row.AccountID, row.AssetType, row.AssetIssuer, row.AssetCode, row.LiquidityPoolID,
 		balance, limit, buyLiab, sellLiab,
 		row.Flags, row.LastModifiedLedger, row.LedgerSequence, row.CreatedAt, row.Sponsor, row.LedgerRange,
+		row.EraID, row.VersionLabel,
 	}, nil
 }
 
@@ -798,6 +805,7 @@ func (row *OfferCurrentRow) OfferCurrentValues() ([]interface{}, error) {
 		row.BuyingAssetType, row.BuyingAssetCode, row.BuyingAssetIssuer,
 		amount, row.PriceN, row.PriceD, row.Price, row.Flags,
 		row.LastModifiedLedger, row.LedgerSequence, row.CreatedAt, row.Sponsor, row.LedgerRange,
+		row.EraID, row.VersionLabel,
 	}, nil
 }
 
@@ -816,6 +824,7 @@ func (row *ContractInvocationRow) Values() []interface{} {
 		row.LedgerSequence, row.TransactionIndex, row.OperationIndex,
 		row.TransactionHash, row.SourceAccount, row.ContractID, row.FunctionName,
 		row.ArgumentsJSON, row.Successful, row.ClosedAt, row.LedgerRange,
+		row.EraID, row.VersionLabel,
 	}
 }
 

--- a/obsrvr-lake/stellar-history-loader/go/go.mod
+++ b/obsrvr-lake/stellar-history-loader/go/go.mod
@@ -99,7 +99,7 @@ require (
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/twpayne/go-geom v1.6.1 // indirect
-	github.com/withObsrvr/stellar-extract v0.1.1
+	github.com/withObsrvr/stellar-extract v0.1.2
 	github.com/zeebo/xxh3 v1.1.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.38.0 // indirect

--- a/obsrvr-lake/stellar-history-loader/go/go.sum
+++ b/obsrvr-lake/stellar-history-loader/go/go.sum
@@ -281,8 +281,8 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.34.0 h1:d3AAQJ2DRcxJYHm7OXNXtXt2as1vMDfxeIcFvhmGGm4=
 github.com/valyala/fasthttp v1.34.0/go.mod h1:epZA5N+7pY6ZaEKRmstzOuYJx9HI8DI1oaCGZpdH4h0=
-github.com/withObsrvr/stellar-extract v0.1.1 h1:SQVnZ+CNlkEI4ux6LaKFkhYIcJ5uOK3yPfMLSQFdxqI=
-github.com/withObsrvr/stellar-extract v0.1.1/go.mod h1:NvqDW54hFJ9aJ78YoOzAFD9eYnmGsQzLRPCig6E0w+g=
+github.com/withObsrvr/stellar-extract v0.1.2 h1:SOSjGIkRmzYWAnCzg9e7L92Z//6qo3kfJsgldgqA8gI=
+github.com/withObsrvr/stellar-extract v0.1.2/go.mod h1:NvqDW54hFJ9aJ78YoOzAFD9eYnmGsQzLRPCig6E0w+g=
 github.com/xdrpp/goxdr v0.1.1 h1:E1B2c6E8eYhOVyd7yEpOyopzTPirUeF6mVOfXfGyJyc=
 github.com/xdrpp/goxdr v0.1.1/go.mod h1:dXo1scL/l6s7iME1gxHWo2XCppbHEKZS7m/KyYWkNzA=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=

--- a/obsrvr-lake/stellar-postgres-ingester/config.yaml
+++ b/obsrvr-lake/stellar-postgres-ingester/config.yaml
@@ -8,6 +8,8 @@ source:
   network_passphrase: "Test SDF Network ; September 2015"
   start_ledger: 1000000
   end_ledger: 1001000
+  era_id: ""
+  version_label: "live"
 
 postgres:
   host: localhost

--- a/obsrvr-lake/stellar-postgres-ingester/go/config.go
+++ b/obsrvr-lake/stellar-postgres-ingester/go/config.go
@@ -20,6 +20,8 @@ type Config struct {
 		NetworkPassphrase string `yaml:"network_passphrase"`
 		StartLedger       uint32 `yaml:"start_ledger"`
 		EndLedger         uint32 `yaml:"end_ledger"` // 0 = continuous (live mode)
+		EraID             string `yaml:"era_id"`
+		VersionLabel      string `yaml:"version_label"`
 	} `yaml:"source"`
 
 	Postgres struct {
@@ -72,8 +74,22 @@ func LoadConfig(path string) (*Config, error) {
 	if cfg.Postgres.SSLMode == "" {
 		cfg.Postgres.SSLMode = "disable"
 	}
+	if cfg.Source.VersionLabel == "" {
+		cfg.Source.VersionLabel = "live"
+	}
 
 	return &cfg, nil
+}
+
+func (c *Config) EraIDPtr() *string {
+	if c.Source.EraID == "" {
+		return nil
+	}
+	return &c.Source.EraID
+}
+
+func (c *Config) VersionLabel() string {
+	return c.Source.VersionLabel
 }
 
 // GetPostgresConnectionString returns a connection string for PostgreSQL

--- a/obsrvr-lake/stellar-postgres-ingester/go/go.mod
+++ b/obsrvr-lake/stellar-postgres-ingester/go/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/jackc/pgx/v5 v5.7.2
 	github.com/stellar/go-stellar-sdk v0.5.0
 	github.com/withObsrvr/flow-proto v0.1.3
-	github.com/withObsrvr/stellar-extract v0.1.1
+	github.com/withObsrvr/stellar-extract v0.1.2
 	github.com/withObsrvr/ttp-processor-demo/stellar-live-source-datalake/go v0.0.0-00010101000000-000000000000
 	google.golang.org/grpc v1.79.3
 	google.golang.org/protobuf v1.36.11

--- a/obsrvr-lake/stellar-postgres-ingester/go/go.sum
+++ b/obsrvr-lake/stellar-postgres-ingester/go/go.sum
@@ -231,8 +231,8 @@ github.com/valyala/fasthttp v1.34.0 h1:d3AAQJ2DRcxJYHm7OXNXtXt2as1vMDfxeIcFvhmGG
 github.com/valyala/fasthttp v1.34.0/go.mod h1:epZA5N+7pY6ZaEKRmstzOuYJx9HI8DI1oaCGZpdH4h0=
 github.com/withObsrvr/flow-proto v0.1.3 h1:L6uCl7HgnHS7g81TX2faQnYLjKJAXRjgudI0elCxW6M=
 github.com/withObsrvr/flow-proto v0.1.3/go.mod h1:gCX0x2CG0FR7Ndg6yPzeQjK1qRIr2K5zgw4d+uFHeNw=
-github.com/withObsrvr/stellar-extract v0.1.1 h1:SQVnZ+CNlkEI4ux6LaKFkhYIcJ5uOK3yPfMLSQFdxqI=
-github.com/withObsrvr/stellar-extract v0.1.1/go.mod h1:NvqDW54hFJ9aJ78YoOzAFD9eYnmGsQzLRPCig6E0w+g=
+github.com/withObsrvr/stellar-extract v0.1.2 h1:SOSjGIkRmzYWAnCzg9e7L92Z//6qo3kfJsgldgqA8gI=
+github.com/withObsrvr/stellar-extract v0.1.2/go.mod h1:NvqDW54hFJ9aJ78YoOzAFD9eYnmGsQzLRPCig6E0w+g=
 github.com/xdrpp/goxdr v0.1.1 h1:E1B2c6E8eYhOVyd7yEpOyopzTPirUeF6mVOfXfGyJyc=
 github.com/xdrpp/goxdr v0.1.1/go.mod h1:dXo1scL/l6s7iME1gxHWo2XCppbHEKZS7m/KyYWkNzA=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=

--- a/obsrvr-lake/stellar-postgres-ingester/go/types.go
+++ b/obsrvr-lake/stellar-postgres-ingester/go/types.go
@@ -18,6 +18,8 @@ type TransactionData struct {
 	CreatedAt             time.Time
 	AccountSequence       int64
 	LedgerRange           uint32
+	EraID                 *string
+	VersionLabel          string
 	SignaturesCount       int
 	NewAccount            bool
 	// Soroban rent tracking (C13)
@@ -43,19 +45,21 @@ type OperationData struct {
 	TransactionSuccessful bool
 	OperationResultCode   *string
 	LedgerRange           uint32
+	EraID                 *string
+	VersionLabel          string
 	// Core operation fields
-	Amount                *int64
-	Asset                 *string
-	Destination           *string
+	Amount      *int64
+	Asset       *string
+	Destination *string
 	// Soroban contract invocation fields
 	SorobanOperation     *string // Host function type: InvokeContract, CreateContract, UploadWasm, etc.
 	SorobanContractID    *string
 	SorobanFunction      *string
 	SorobanArgumentsJSON *string
 	// Call graph fields (cross-contract call tracking)
-	ContractCallsJSON  *string   // JSON array of {from, to, function, depth, order}
-	ContractsInvolved  []string  // All contracts in the call chain
-	MaxCallDepth       *int      // Maximum depth of nested calls
+	ContractCallsJSON *string  // JSON array of {from, to, function, depth, order}
+	ContractsInvolved []string // All contracts in the call chain
+	MaxCallDepth      *int     // Maximum depth of nested calls
 	// Soroban authorization fields (SorobanAuthorizationEntry.Credentials).
 	// Parallel arrays; same length; one entry per auth entry on the op.
 	// nil on non-Soroban ops and InvokeHostFunction ops with zero auth entries.
@@ -66,11 +70,11 @@ type OperationData struct {
 // EffectData represents a single effect (state changes from operations)
 type EffectData struct {
 	// Identity
-	LedgerSequence   uint32
-	TransactionHash  string
-	OperationIndex   int
-	EffectIndex      int
-	OperationID      int64 // TOID of parent operation
+	LedgerSequence  uint32
+	TransactionHash string
+	OperationIndex  int
+	EffectIndex     int
+	OperationID     int64 // TOID of parent operation
 
 	// Effect type
 	EffectType       int
@@ -98,8 +102,10 @@ type EffectData struct {
 	SellerAccount  *string
 
 	// Metadata
-	CreatedAt   time.Time
-	LedgerRange uint32
+	CreatedAt    time.Time
+	LedgerRange  uint32
+	EraID        *string
+	VersionLabel string
 }
 
 // TradeData represents a single trade execution (DEX trades)
@@ -130,8 +136,10 @@ type TradeData struct {
 	Price string
 
 	// Metadata
-	CreatedAt   time.Time
-	LedgerRange uint32
+	CreatedAt    time.Time
+	LedgerRange  uint32
+	EraID        *string
+	VersionLabel string
 }
 
 // AccountData represents account snapshot state (accounts_snapshot_v1)
@@ -172,9 +180,11 @@ type AccountData struct {
 	SponsorAccount *string
 
 	// Metadata (3 fields)
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
-	LedgerRange uint32
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+	LedgerRange  uint32
+	EraID        *string
+	VersionLabel string
 }
 
 // OfferData represents DEX offer snapshot state (offers_snapshot_v1)
@@ -204,8 +214,10 @@ type OfferData struct {
 	Flags uint32
 
 	// Metadata (2 fields)
-	CreatedAt   time.Time
-	LedgerRange uint32
+	CreatedAt    time.Time
+	LedgerRange  uint32
+	EraID        *string
+	VersionLabel string
 }
 
 // TrustlineData represents trustline snapshot state (trustlines_snapshot_v1)
@@ -232,6 +244,8 @@ type TrustlineData struct {
 	LedgerSequence uint32
 	CreatedAt      time.Time
 	LedgerRange    uint32
+	EraID          *string
+	VersionLabel   string
 }
 
 // AccountSignerData represents account signer snapshot state (account_signers_snapshot_v1)
@@ -250,9 +264,11 @@ type AccountSignerData struct {
 	Deleted bool
 
 	// Metadata (3 fields)
-	ClosedAt    time.Time
-	LedgerRange uint32
-	CreatedAt   time.Time
+	ClosedAt     time.Time
+	LedgerRange  uint32
+	CreatedAt    time.Time
+	EraID        *string
+	VersionLabel string
 }
 
 // ClaimableBalanceData represents claimable balance snapshot state (claimable_balances_snapshot_v1)
@@ -277,8 +293,10 @@ type ClaimableBalanceData struct {
 	Flags uint32
 
 	// Metadata (2 fields)
-	CreatedAt   time.Time
-	LedgerRange uint32
+	CreatedAt    time.Time
+	LedgerRange  uint32
+	EraID        *string
+	VersionLabel string
 }
 
 // LiquidityPoolData represents liquidity pool snapshot state (liquidity_pools_snapshot_v1)
@@ -312,8 +330,10 @@ type LiquidityPoolData struct {
 	AssetBAmount int64
 
 	// Metadata (2 fields)
-	CreatedAt   time.Time
-	LedgerRange uint32
+	CreatedAt    time.Time
+	LedgerRange  uint32
+	EraID        *string
+	VersionLabel string
 }
 
 // ConfigSettingData represents network configuration settings snapshot (config_settings_snapshot_v1)
@@ -351,8 +371,10 @@ type ConfigSettingData struct {
 	ConfigSettingXDR string
 
 	// Metadata (2 fields)
-	CreatedAt   time.Time
-	LedgerRange uint32
+	CreatedAt    time.Time
+	LedgerRange  uint32
+	EraID        *string
+	VersionLabel string
 }
 
 // TTLData represents time-to-live entries snapshot (ttl_snapshot_v1)
@@ -373,8 +395,10 @@ type TTLData struct {
 	ClosedAt           time.Time
 
 	// Metadata (2 fields)
-	CreatedAt   time.Time
-	LedgerRange uint32
+	CreatedAt    time.Time
+	LedgerRange  uint32
+	EraID        *string
+	VersionLabel string
 }
 
 // EvictedKeyData represents evicted storage keys state (evicted_keys_state_v1)
@@ -390,9 +414,11 @@ type EvictedKeyData struct {
 	Durability string
 
 	// Metadata (3 fields)
-	ClosedAt    time.Time
-	LedgerRange uint32
-	CreatedAt   time.Time
+	ClosedAt     time.Time
+	LedgerRange  uint32
+	CreatedAt    time.Time
+	EraID        *string
+	VersionLabel string
 }
 
 // ContractEventData represents Soroban contract events stream (contract_events_stream_v1)
@@ -429,8 +455,10 @@ type ContractEventData struct {
 	EventIndex     uint32
 
 	// Metadata (2 fields)
-	CreatedAt   time.Time
-	LedgerRange uint32
+	CreatedAt    time.Time
+	LedgerRange  uint32
+	EraID        *string
+	VersionLabel string
 }
 
 // ContractCall represents a single cross-contract call in the call graph
@@ -488,8 +516,10 @@ type ContractDataData struct {
 	TokenDecimals *int32
 
 	// Metadata (2 fields)
-	CreatedAt   time.Time
-	LedgerRange uint32
+	CreatedAt    time.Time
+	LedgerRange  uint32
+	EraID        *string
+	VersionLabel string
 }
 
 // ContractCodeData represents Soroban contract code snapshot (contract_code_snapshot_v1)
@@ -524,8 +554,10 @@ type ContractCodeData struct {
 	NDataSegmentBytes *int64
 
 	// Metadata (2 fields)
-	CreatedAt   time.Time
-	LedgerRange uint32
+	CreatedAt    time.Time
+	LedgerRange  uint32
+	EraID        *string
+	VersionLabel string
 }
 
 // NativeBalanceData represents XLM-only balances snapshot (native_balances_snapshot_v1)
@@ -548,7 +580,9 @@ type NativeBalanceData struct {
 	LedgerSequence     int64
 
 	// Partition key (1 field)
-	LedgerRange int64
+	LedgerRange  int64
+	EraID        *string
+	VersionLabel string
 }
 
 // RestoredKeyData represents restored storage keys state (restored_keys_state_v1)
@@ -565,9 +599,11 @@ type RestoredKeyData struct {
 	RestoredFromLedger uint32
 
 	// Metadata (3 fields)
-	ClosedAt    time.Time
-	LedgerRange uint32
-	CreatedAt   time.Time
+	ClosedAt     time.Time
+	LedgerRange  uint32
+	CreatedAt    time.Time
+	EraID        *string
+	VersionLabel string
 }
 
 // ContractCreationData represents a contract creation event
@@ -578,6 +614,8 @@ type ContractCreationData struct {
 	CreatedLedger  uint32
 	CreatedAt      time.Time
 	LedgerRange    uint32
+	EraID          *string
+	VersionLabel   string
 }
 
 // TokenTransferData represents a unified token transfer event (token_transfers_stream_v1)
@@ -601,6 +639,8 @@ type TokenTransferData struct {
 	ClosedAt        time.Time
 	CreatedAt       time.Time
 	LedgerRange     uint32
+	EraID           *string
+	VersionLabel    string
 }
 
 // Note: Cycle 2 MVP complete (5 of 19 Hubble tables): ledgers, transactions, operations, effects, trades

--- a/obsrvr-lake/stellar-postgres-ingester/go/writer.go
+++ b/obsrvr-lake/stellar-postgres-ingester/go/writer.go
@@ -56,6 +56,8 @@ type LedgerData struct {
 	EvictedKeysCount     *int
 	IngestionTimestamp   time.Time
 	LedgerRange          uint32
+	EraID                *string
+	VersionLabel         string
 	// Soroban aggregates per ledger
 	SorobanOpCount      *int
 	TotalFeeCharged     *int64
@@ -142,18 +144,22 @@ func (w *Writer) WriteBatch(ctx context.Context, rawLedgers []*pb.RawLedger) err
 	// Contract creation tracking (C11)
 	var allContractCreations []ContractCreationData
 
+	versionLabel := w.config.VersionLabel()
 	for _, rawLedger := range rawLedgers {
 		// Create the library input ONCE per ledger (decodes XDR)
 		input, err := extract.NewLedgerInputFromXDR(rawLedger.LedgerCloseMetaXdr, w.config.Source.NetworkPassphrase)
 		if err != nil {
 			return fmt.Errorf("failed to decode ledger %d: %w", rawLedger.Sequence, err)
 		}
+		input.EraID = w.config.EraIDPtr()
 
 		// Extract ledger data (local method — uses pre-decoded LCM)
 		ledgerData, err := w.extractLedgerDataFromLCM(input.LCM)
 		if err != nil {
 			return fmt.Errorf("failed to extract ledger %d: %w", rawLedger.Sequence, err)
 		}
+		ledgerData.EraID = input.EraID
+		ledgerData.VersionLabel = versionLabel
 
 		// Extract transactions via library
 		libTransactions, err := extract.ExtractTransactions(input)
@@ -161,7 +167,10 @@ func (w *Writer) WriteBatch(ctx context.Context, rawLedgers []*pb.RawLedger) err
 			log.Printf("Warning: Failed to extract transactions for ledger %d: %v", rawLedger.Sequence, err)
 		} else {
 			for _, r := range libTransactions {
-				allTransactions = append(allTransactions, convertTransaction(r))
+				row := convertTransaction(r)
+				row.EraID = input.EraID
+				row.VersionLabel = versionLabel
+				allTransactions = append(allTransactions, row)
 			}
 		}
 
@@ -173,7 +182,10 @@ func (w *Writer) WriteBatch(ctx context.Context, rawLedgers []*pb.RawLedger) err
 			sorobanOps := 0
 			convertedOps := make([]OperationData, 0, len(libOperations))
 			for _, r := range libOperations {
-				convertedOps = append(convertedOps, convertOperation(r))
+				row := convertOperation(r)
+				row.EraID = input.EraID
+				row.VersionLabel = versionLabel
+				convertedOps = append(convertedOps, row)
 				if r.LedgerSequence == ledgerData.Sequence {
 					if r.OpType == 24 || r.OpType == 25 || r.OpType == 26 {
 						sorobanOps++
@@ -203,7 +215,10 @@ func (w *Writer) WriteBatch(ctx context.Context, rawLedgers []*pb.RawLedger) err
 			log.Printf("Warning: Failed to extract effects for ledger %d: %v", rawLedger.Sequence, err)
 		} else {
 			for _, r := range libEffects {
-				allEffects = append(allEffects, convertEffect(r))
+				row := convertEffect(r)
+				row.EraID = input.EraID
+				row.VersionLabel = versionLabel
+				allEffects = append(allEffects, row)
 			}
 		}
 
@@ -213,7 +228,10 @@ func (w *Writer) WriteBatch(ctx context.Context, rawLedgers []*pb.RawLedger) err
 			log.Printf("Warning: Failed to extract trades for ledger %d: %v", rawLedger.Sequence, err)
 		} else {
 			for _, r := range libTrades {
-				allTrades = append(allTrades, convertTrade(r))
+				row := convertTrade(r)
+				row.EraID = input.EraID
+				row.VersionLabel = versionLabel
+				allTrades = append(allTrades, row)
 			}
 		}
 
@@ -223,7 +241,10 @@ func (w *Writer) WriteBatch(ctx context.Context, rawLedgers []*pb.RawLedger) err
 			log.Printf("Warning: Failed to extract accounts for ledger %d: %v", rawLedger.Sequence, err)
 		} else {
 			for _, r := range libAccounts {
-				allAccounts = append(allAccounts, convertAccount(r))
+				row := convertAccount(r)
+				row.EraID = input.EraID
+				row.VersionLabel = versionLabel
+				allAccounts = append(allAccounts, row)
 			}
 		}
 
@@ -233,7 +254,10 @@ func (w *Writer) WriteBatch(ctx context.Context, rawLedgers []*pb.RawLedger) err
 			log.Printf("Warning: Failed to extract offers for ledger %d: %v", rawLedger.Sequence, err)
 		} else {
 			for _, r := range libOffers {
-				allOffers = append(allOffers, convertOffer(r))
+				row := convertOffer(r)
+				row.EraID = input.EraID
+				row.VersionLabel = versionLabel
+				allOffers = append(allOffers, row)
 			}
 		}
 
@@ -243,7 +267,10 @@ func (w *Writer) WriteBatch(ctx context.Context, rawLedgers []*pb.RawLedger) err
 			log.Printf("Warning: Failed to extract trustlines for ledger %d: %v", rawLedger.Sequence, err)
 		} else {
 			for _, r := range libTrustlines {
-				allTrustlines = append(allTrustlines, convertTrustline(r))
+				row := convertTrustline(r)
+				row.EraID = input.EraID
+				row.VersionLabel = versionLabel
+				allTrustlines = append(allTrustlines, row)
 			}
 		}
 
@@ -253,7 +280,10 @@ func (w *Writer) WriteBatch(ctx context.Context, rawLedgers []*pb.RawLedger) err
 			log.Printf("Warning: Failed to extract account signers for ledger %d: %v", rawLedger.Sequence, err)
 		} else {
 			for _, r := range libAccountSigners {
-				allAccountSigners = append(allAccountSigners, convertAccountSigner(r))
+				row := convertAccountSigner(r)
+				row.EraID = input.EraID
+				row.VersionLabel = versionLabel
+				allAccountSigners = append(allAccountSigners, row)
 			}
 		}
 
@@ -263,7 +293,10 @@ func (w *Writer) WriteBatch(ctx context.Context, rawLedgers []*pb.RawLedger) err
 			log.Printf("Warning: Failed to extract claimable balances for ledger %d: %v", rawLedger.Sequence, err)
 		} else {
 			for _, r := range libClaimableBalances {
-				allClaimableBalances = append(allClaimableBalances, convertClaimableBalance(r))
+				row := convertClaimableBalance(r)
+				row.EraID = input.EraID
+				row.VersionLabel = versionLabel
+				allClaimableBalances = append(allClaimableBalances, row)
 			}
 		}
 
@@ -273,7 +306,10 @@ func (w *Writer) WriteBatch(ctx context.Context, rawLedgers []*pb.RawLedger) err
 			log.Printf("Warning: Failed to extract liquidity pools for ledger %d: %v", rawLedger.Sequence, err)
 		} else {
 			for _, r := range libLiquidityPools {
-				allLiquidityPools = append(allLiquidityPools, convertLiquidityPool(r))
+				row := convertLiquidityPool(r)
+				row.EraID = input.EraID
+				row.VersionLabel = versionLabel
+				allLiquidityPools = append(allLiquidityPools, row)
 			}
 		}
 
@@ -283,7 +319,10 @@ func (w *Writer) WriteBatch(ctx context.Context, rawLedgers []*pb.RawLedger) err
 			log.Printf("Warning: Failed to extract config settings for ledger %d: %v", rawLedger.Sequence, err)
 		} else {
 			for _, r := range libConfigSettings {
-				allConfigSettings = append(allConfigSettings, convertConfigSetting(r))
+				row := convertConfigSetting(r)
+				row.EraID = input.EraID
+				row.VersionLabel = versionLabel
+				allConfigSettings = append(allConfigSettings, row)
 			}
 		}
 
@@ -293,7 +332,10 @@ func (w *Writer) WriteBatch(ctx context.Context, rawLedgers []*pb.RawLedger) err
 			log.Printf("Warning: Failed to extract TTL for ledger %d: %v", rawLedger.Sequence, err)
 		} else {
 			for _, r := range libTTL {
-				allTTL = append(allTTL, convertTTL(r))
+				row := convertTTL(r)
+				row.EraID = input.EraID
+				row.VersionLabel = versionLabel
+				allTTL = append(allTTL, row)
 			}
 		}
 
@@ -303,7 +345,10 @@ func (w *Writer) WriteBatch(ctx context.Context, rawLedgers []*pb.RawLedger) err
 			log.Printf("Warning: Failed to extract evicted keys for ledger %d: %v", rawLedger.Sequence, err)
 		} else {
 			for _, r := range libEvictedKeys {
-				allEvictedKeys = append(allEvictedKeys, convertEvictedKey(r))
+				row := convertEvictedKey(r)
+				row.EraID = input.EraID
+				row.VersionLabel = versionLabel
+				allEvictedKeys = append(allEvictedKeys, row)
 			}
 		}
 
@@ -313,7 +358,10 @@ func (w *Writer) WriteBatch(ctx context.Context, rawLedgers []*pb.RawLedger) err
 			log.Printf("Warning: Failed to extract contract events for ledger %d: %v", rawLedger.Sequence, err)
 		} else {
 			for _, r := range libContractEvents {
-				allContractEvents = append(allContractEvents, convertContractEvent(r))
+				row := convertContractEvent(r)
+				row.EraID = input.EraID
+				row.VersionLabel = versionLabel
+				allContractEvents = append(allContractEvents, row)
 			}
 		}
 
@@ -323,7 +371,10 @@ func (w *Writer) WriteBatch(ctx context.Context, rawLedgers []*pb.RawLedger) err
 			log.Printf("Warning: Failed to extract contract data for ledger %d: %v", rawLedger.Sequence, err)
 		} else {
 			for _, r := range libContractData {
-				allContractData = append(allContractData, convertContractData(r))
+				row := convertContractData(r)
+				row.EraID = input.EraID
+				row.VersionLabel = versionLabel
+				allContractData = append(allContractData, row)
 			}
 		}
 
@@ -333,7 +384,10 @@ func (w *Writer) WriteBatch(ctx context.Context, rawLedgers []*pb.RawLedger) err
 			log.Printf("Warning: Failed to extract contract code for ledger %d: %v", rawLedger.Sequence, err)
 		} else {
 			for _, r := range libContractCode {
-				allContractCode = append(allContractCode, convertContractCode(r))
+				row := convertContractCode(r)
+				row.EraID = input.EraID
+				row.VersionLabel = versionLabel
+				allContractCode = append(allContractCode, row)
 			}
 		}
 
@@ -343,7 +397,10 @@ func (w *Writer) WriteBatch(ctx context.Context, rawLedgers []*pb.RawLedger) err
 			log.Printf("Warning: Failed to extract native balances for ledger %d: %v", rawLedger.Sequence, err)
 		} else {
 			for _, r := range libNativeBalances {
-				allNativeBalances = append(allNativeBalances, convertNativeBalance(r))
+				row := convertNativeBalance(r)
+				row.EraID = input.EraID
+				row.VersionLabel = versionLabel
+				allNativeBalances = append(allNativeBalances, row)
 			}
 		}
 
@@ -353,7 +410,10 @@ func (w *Writer) WriteBatch(ctx context.Context, rawLedgers []*pb.RawLedger) err
 			log.Printf("Warning: Failed to extract restored keys for ledger %d: %v", rawLedger.Sequence, err)
 		} else {
 			for _, r := range libRestoredKeys {
-				allRestoredKeys = append(allRestoredKeys, convertRestoredKey(r))
+				row := convertRestoredKey(r)
+				row.EraID = input.EraID
+				row.VersionLabel = versionLabel
+				allRestoredKeys = append(allRestoredKeys, row)
 			}
 		}
 
@@ -363,7 +423,10 @@ func (w *Writer) WriteBatch(ctx context.Context, rawLedgers []*pb.RawLedger) err
 			log.Printf("Warning: Failed to extract contract creations for ledger %d: %v", rawLedger.Sequence, err)
 		} else {
 			for _, r := range libContractCreations {
-				allContractCreations = append(allContractCreations, convertContractCreation(r))
+				row := convertContractCreation(r)
+				row.EraID = input.EraID
+				row.VersionLabel = versionLabel
+				allContractCreations = append(allContractCreations, row)
 			}
 		}
 
@@ -373,7 +436,10 @@ func (w *Writer) WriteBatch(ctx context.Context, rawLedgers []*pb.RawLedger) err
 			log.Printf("Warning: Failed to extract token transfers for ledger %d: %v", rawLedger.Sequence, err)
 		} else {
 			for _, r := range libTokenTransfers {
-				allTokenTransfers = append(allTokenTransfers, convertTokenTransfer(r))
+				row := convertTokenTransfer(r)
+				row.EraID = input.EraID
+				row.VersionLabel = versionLabel
+				allTokenTransfers = append(allTokenTransfers, row)
 			}
 		}
 
@@ -1347,11 +1413,12 @@ func (w *Writer) insertLedger(ctx context.Context, tx pgx.Tx, ledger *LedgerData
 			transaction_count, operation_count, tx_set_operation_count,
 			soroban_fee_write1kb, node_id, signature, ledger_header,
 			bucket_list_size, live_soroban_state_size, evicted_keys_count,
-			soroban_op_count, total_fee_charged, contract_events_count
+			soroban_op_count, total_fee_charged, contract_events_count,
+			era_id, version_label
 		) VALUES (
 			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
 			$11, $12, $13, $14, $15, $16, $17, $18, $19, $20,
-			$21, $22, $23, $24, $25, $26, $27
+			$21, $22, $23, $24, $25, $26, $27, $28, $29
 		)
 		ON CONFLICT (sequence) DO UPDATE SET
 			ledger_hash = EXCLUDED.ledger_hash,
@@ -1362,7 +1429,9 @@ func (w *Writer) insertLedger(ctx context.Context, tx pgx.Tx, ledger *LedgerData
 			failed_tx_count = EXCLUDED.failed_tx_count,
 			soroban_op_count = EXCLUDED.soroban_op_count,
 			total_fee_charged = EXCLUDED.total_fee_charged,
-			contract_events_count = EXCLUDED.contract_events_count
+			contract_events_count = EXCLUDED.contract_events_count,
+			era_id = EXCLUDED.era_id,
+			version_label = EXCLUDED.version_label
 	`
 
 	_, err := tx.Exec(ctx, query,
@@ -1393,6 +1462,8 @@ func (w *Writer) insertLedger(ctx context.Context, tx pgx.Tx, ledger *LedgerData
 		ledger.SorobanOpCount,
 		ledger.TotalFeeCharged,
 		ledger.ContractEventsCount,
+		ledger.EraID,
+		ledger.VersionLabel,
 	)
 
 	return err
@@ -1409,12 +1480,14 @@ func (w *Writer) insertTransactions(ctx context.Context, tx pgx.Tx, transactions
 			ledger_sequence, transaction_hash, transaction_id, source_account, fee_charged,
 			max_fee, successful, transaction_result_code, operation_count,
 			memo_type, memo, created_at, account_sequence, ledger_range,
+			era_id, version_label,
 			signatures_count, new_account, rent_fee_charged,
 			soroban_resources_instructions, soroban_resources_read_bytes,
 			soroban_resources_write_bytes
 		) VALUES (
 			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
-			$11, $12, $13, $14, $15, $16, $17, $18, $19, $20
+			$11, $12, $13, $14, $15, $16, $17, $18, $19, $20,
+			$21, $22
 		)
 		ON CONFLICT (ledger_sequence, transaction_hash) DO UPDATE SET
 			transaction_id = EXCLUDED.transaction_id,
@@ -1423,7 +1496,9 @@ func (w *Writer) insertTransactions(ctx context.Context, tx pgx.Tx, transactions
 			rent_fee_charged = EXCLUDED.rent_fee_charged,
 			soroban_resources_instructions = EXCLUDED.soroban_resources_instructions,
 			soroban_resources_read_bytes = EXCLUDED.soroban_resources_read_bytes,
-			soroban_resources_write_bytes = EXCLUDED.soroban_resources_write_bytes
+			soroban_resources_write_bytes = EXCLUDED.soroban_resources_write_bytes,
+			era_id = EXCLUDED.era_id,
+			version_label = EXCLUDED.version_label
 	`
 
 	batch := &pgx.Batch{}
@@ -1450,6 +1525,8 @@ func (w *Writer) insertTransactions(ctx context.Context, tx pgx.Tx, transactions
 			txData.CreatedAt,
 			txData.AccountSequence,
 			txData.LedgerRange,
+			txData.EraID,
+			txData.VersionLabel,
 			txData.SignaturesCount,
 			txData.NewAccount,
 			txData.RentFeeCharged,
@@ -1481,14 +1558,14 @@ func (w *Writer) insertOperations(ctx context.Context, tx pgx.Tx, operations []O
 			transaction_hash, transaction_id, operation_id,
 			transaction_index, operation_index, ledger_sequence, source_account,
 			type, type_string, created_at, transaction_successful,
-			operation_result_code, ledger_range, amount, asset, destination,
+			operation_result_code, ledger_range, era_id, version_label, amount, asset, destination,
 			soroban_operation, soroban_contract_id, soroban_function, soroban_arguments_json,
 			contract_calls_json, contracts_involved, max_call_depth,
 			soroban_auth_credentials_types, soroban_auth_addresses
 		) VALUES (
 			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
 			$11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23,
-			$24, $25
+			$24, $25, $26, $27
 		)
 		ON CONFLICT (ledger_sequence, transaction_hash, operation_index) DO UPDATE SET
 			transaction_id = EXCLUDED.transaction_id,
@@ -1503,7 +1580,9 @@ func (w *Writer) insertOperations(ctx context.Context, tx pgx.Tx, operations []O
 			contracts_involved = EXCLUDED.contracts_involved,
 			max_call_depth = EXCLUDED.max_call_depth,
 			soroban_auth_credentials_types = EXCLUDED.soroban_auth_credentials_types,
-			soroban_auth_addresses = EXCLUDED.soroban_auth_addresses
+			soroban_auth_addresses = EXCLUDED.soroban_auth_addresses,
+			era_id = EXCLUDED.era_id,
+			version_label = EXCLUDED.version_label
 	`
 
 	batch := &pgx.Batch{}
@@ -1532,6 +1611,8 @@ func (w *Writer) insertOperations(ctx context.Context, tx pgx.Tx, operations []O
 			opData.TransactionSuccessful,
 			opData.OperationResultCode,
 			opData.LedgerRange,
+			opData.EraID,
+			opData.VersionLabel,
 			opData.Amount,
 			opData.Asset,
 			opData.Destination,
@@ -1573,10 +1654,10 @@ func (w *Writer) insertEffects(ctx context.Context, tx pgx.Tx, effects []EffectD
 			trustline_limit, authorize_flag, clawback_flag,
 			signer_account, signer_weight,
 			offer_id, seller_account,
-			created_at, ledger_range
+			created_at, ledger_range, era_id, version_label
 		) VALUES (
 			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
-			$11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22
+			$11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24
 		)
 		ON CONFLICT (ledger_sequence, transaction_hash, operation_index, effect_index) DO NOTHING
 	`
@@ -1619,6 +1700,8 @@ func (w *Writer) insertEffects(ctx context.Context, tx pgx.Tx, effects []EffectD
 			e.SellerAccount,
 			e.CreatedAt,
 			e.LedgerRange,
+			e.EraID,
+			e.VersionLabel,
 		)
 	}
 
@@ -1646,10 +1729,10 @@ func (w *Writer) insertTrades(ctx context.Context, tx pgx.Tx, trades []TradeData
 			trade_type, trade_timestamp,
 			seller_account, selling_asset_code, selling_asset_issuer, selling_amount,
 			buyer_account, buying_asset_code, buying_asset_issuer, buying_amount,
-			price, created_at, ledger_range
+			price, created_at, ledger_range, era_id, version_label
 		) VALUES (
 			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
-			$11, $12, $13, $14, $15, $16, $17
+			$11, $12, $13, $14, $15, $16, $17, $18, $19
 		)
 		ON CONFLICT (ledger_sequence, transaction_hash, operation_index, trade_index) DO NOTHING
 	`
@@ -1673,6 +1756,8 @@ func (w *Writer) insertTrades(ctx context.Context, tx pgx.Tx, trades []TradeData
 			tradeData.Price,
 			tradeData.CreatedAt,
 			tradeData.LedgerRange,
+			tradeData.EraID,
+			tradeData.VersionLabel,
 		)
 		if err != nil {
 			return fmt.Errorf("failed to insert trade %s:%d:%d: %w",
@@ -1696,18 +1781,20 @@ func (w *Writer) insertAccounts(ctx context.Context, tx pgx.Tx, accounts []Accou
 			master_weight, low_threshold, med_threshold, high_threshold,
 			flags, auth_required, auth_revocable, auth_immutable, auth_clawback_enabled,
 			signers, sponsor_account,
-			created_at, updated_at, ledger_range
+			created_at, updated_at, ledger_range, era_id, version_label
 		) VALUES (
 			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
 			$11, $12, $13, $14, $15, $16, $17, $18,
-			$19, $20, $21, $22, $23
+			$19, $20, $21, $22, $23, $24, $25
 		)
 		ON CONFLICT (account_id, ledger_sequence) DO UPDATE SET
 			balance = EXCLUDED.balance,
 			sequence_number = EXCLUDED.sequence_number,
 			num_subentries = EXCLUDED.num_subentries,
 			flags = EXCLUDED.flags,
-			updated_at = EXCLUDED.updated_at
+			updated_at = EXCLUDED.updated_at,
+			era_id = EXCLUDED.era_id,
+			version_label = EXCLUDED.version_label
 	`
 
 	batch := &pgx.Batch{}
@@ -1742,6 +1829,8 @@ func (w *Writer) insertAccounts(ctx context.Context, tx pgx.Tx, accounts []Accou
 			acct.CreatedAt,
 			acct.UpdatedAt,
 			acct.LedgerRange,
+			acct.EraID,
+			acct.VersionLabel,
 		)
 	}
 
@@ -1768,15 +1857,17 @@ func (w *Writer) insertOffers(ctx context.Context, tx pgx.Tx, offers []OfferData
 			selling_asset_type, selling_asset_code, selling_asset_issuer,
 			buying_asset_type, buying_asset_code, buying_asset_issuer,
 			amount, price, flags,
-			created_at, ledger_range
+			created_at, ledger_range, era_id, version_label
 		) VALUES (
 			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
-			$11, $12, $13, $14, $15
+			$11, $12, $13, $14, $15, $16, $17
 		)
 		ON CONFLICT (offer_id, ledger_sequence) DO UPDATE SET
 			amount = EXCLUDED.amount,
 			price = EXCLUDED.price,
-			created_at = EXCLUDED.created_at
+			created_at = EXCLUDED.created_at,
+			era_id = EXCLUDED.era_id,
+			version_label = EXCLUDED.version_label
 	`
 
 	batch := &pgx.Batch{}
@@ -1798,6 +1889,8 @@ func (w *Writer) insertOffers(ctx context.Context, tx pgx.Tx, offers []OfferData
 			offer.Flags,
 			offer.CreatedAt,
 			offer.LedgerRange,
+			offer.EraID,
+			offer.VersionLabel,
 		)
 	}
 
@@ -1823,10 +1916,10 @@ func (w *Writer) insertTrustlines(ctx context.Context, tx pgx.Tx, trustlines []T
 			account_id, asset_code, asset_issuer, asset_type,
 			balance, trust_limit, buying_liabilities, selling_liabilities,
 			authorized, authorized_to_maintain_liabilities, clawback_enabled,
-			ledger_sequence, created_at, ledger_range
+			ledger_sequence, created_at, ledger_range, era_id, version_label
 		) VALUES (
 			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
-			$11, $12, $13, $14
+			$11, $12, $13, $14, $15, $16
 		)
 		ON CONFLICT (account_id, asset_code, asset_issuer, asset_type, ledger_sequence) DO UPDATE SET
 			balance = EXCLUDED.balance,
@@ -1835,7 +1928,9 @@ func (w *Writer) insertTrustlines(ctx context.Context, tx pgx.Tx, trustlines []T
 			selling_liabilities = EXCLUDED.selling_liabilities,
 			authorized = EXCLUDED.authorized,
 			authorized_to_maintain_liabilities = EXCLUDED.authorized_to_maintain_liabilities,
-			clawback_enabled = EXCLUDED.clawback_enabled
+			clawback_enabled = EXCLUDED.clawback_enabled,
+			era_id = EXCLUDED.era_id,
+			version_label = EXCLUDED.version_label
 	`
 
 	batch := &pgx.Batch{}
@@ -1856,6 +1951,8 @@ func (w *Writer) insertTrustlines(ctx context.Context, tx pgx.Tx, trustlines []T
 			tl.LedgerSequence,
 			tl.CreatedAt,
 			tl.LedgerRange,
+			tl.EraID,
+			tl.VersionLabel,
 		)
 	}
 
@@ -1880,15 +1977,17 @@ func (w *Writer) insertAccountSigners(ctx context.Context, tx pgx.Tx, signers []
 	query := `
 		INSERT INTO account_signers_snapshot_v1 (
 			account_id, signer, ledger_sequence, weight, sponsor,
-			deleted, closed_at, ledger_range, created_at
+			deleted, closed_at, ledger_range, created_at, era_id, version_label
 		) VALUES (
-			$1, $2, $3, $4, $5, $6, $7, $8, $9
+			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
 		)
 		ON CONFLICT (account_id, signer, ledger_sequence) DO UPDATE SET
 			weight = EXCLUDED.weight,
 			sponsor = EXCLUDED.sponsor,
 			deleted = EXCLUDED.deleted,
-			closed_at = EXCLUDED.closed_at
+			closed_at = EXCLUDED.closed_at,
+			era_id = EXCLUDED.era_id,
+			version_label = EXCLUDED.version_label
 	`
 
 	batch := &pgx.Batch{}
@@ -1904,6 +2003,8 @@ func (w *Writer) insertAccountSigners(ctx context.Context, tx pgx.Tx, signers []
 			s.ClosedAt,
 			s.LedgerRange,
 			s.CreatedAt,
+			s.EraID,
+			s.VersionLabel,
 		)
 	}
 
@@ -1937,9 +2038,9 @@ func (w *Writer) insertClaimableBalances(ctx context.Context, tx pgx.Tx, balance
 		INSERT INTO claimable_balances_snapshot_v1 (
 			balance_id, sponsor, ledger_sequence, closed_at,
 			asset_type, asset_code, asset_issuer, amount,
-			claimants_count, flags, created_at, ledger_range
+			claimants_count, flags, created_at, ledger_range, era_id, version_label
 		) VALUES (
-			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12
+			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14
 		)
 		ON CONFLICT (balance_id, ledger_sequence) DO UPDATE SET
 			sponsor = EXCLUDED.sponsor,
@@ -1948,7 +2049,9 @@ func (w *Writer) insertClaimableBalances(ctx context.Context, tx pgx.Tx, balance
 			asset_issuer = EXCLUDED.asset_issuer,
 			amount = EXCLUDED.amount,
 			claimants_count = EXCLUDED.claimants_count,
-			flags = EXCLUDED.flags
+			flags = EXCLUDED.flags,
+			era_id = EXCLUDED.era_id,
+			version_label = EXCLUDED.version_label
 	`
 
 	batch := &pgx.Batch{}
@@ -1967,6 +2070,8 @@ func (w *Writer) insertClaimableBalances(ctx context.Context, tx pgx.Tx, balance
 			bal.Flags,
 			bal.CreatedAt,
 			bal.LedgerRange,
+			bal.EraID,
+			bal.VersionLabel,
 		)
 	}
 
@@ -1993,9 +2098,9 @@ func (w *Writer) insertLiquidityPools(ctx context.Context, tx pgx.Tx, pools []Li
 			pool_type, fee, trustline_count, total_pool_shares,
 			asset_a_type, asset_a_code, asset_a_issuer, asset_a_amount,
 			asset_b_type, asset_b_code, asset_b_issuer, asset_b_amount,
-			created_at, ledger_range
+			created_at, ledger_range, era_id, version_label
 		) VALUES (
-			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17
+			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19
 		)
 		ON CONFLICT (liquidity_pool_id, ledger_sequence) DO UPDATE SET
 			pool_type = EXCLUDED.pool_type,
@@ -2003,7 +2108,9 @@ func (w *Writer) insertLiquidityPools(ctx context.Context, tx pgx.Tx, pools []Li
 			trustline_count = EXCLUDED.trustline_count,
 			total_pool_shares = EXCLUDED.total_pool_shares,
 			asset_a_amount = EXCLUDED.asset_a_amount,
-			asset_b_amount = EXCLUDED.asset_b_amount
+			asset_b_amount = EXCLUDED.asset_b_amount,
+			era_id = EXCLUDED.era_id,
+			version_label = EXCLUDED.version_label
 	`
 
 	batch := &pgx.Batch{}
@@ -2027,6 +2134,8 @@ func (w *Writer) insertLiquidityPools(ctx context.Context, tx pgx.Tx, pools []Li
 			pool.AssetBAmount,
 			pool.CreatedAt,
 			pool.LedgerRange,
+			pool.EraID,
+			pool.VersionLabel,
 		)
 	}
 
@@ -2053,9 +2162,9 @@ func (w *Writer) insertConfigSettings(ctx context.Context, tx pgx.Tx, settings [
 			ledger_max_instructions, tx_max_instructions, fee_rate_per_instructions_increment, tx_memory_limit,
 			ledger_max_read_ledger_entries, ledger_max_read_bytes, ledger_max_write_ledger_entries, ledger_max_write_bytes,
 			tx_max_read_ledger_entries, tx_max_read_bytes, tx_max_write_ledger_entries, tx_max_write_bytes,
-			contract_max_size_bytes, config_setting_xdr, created_at, ledger_range
+			contract_max_size_bytes, config_setting_xdr, created_at, ledger_range, era_id, version_label
 		) VALUES (
-			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21
+			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23
 		)
 		ON CONFLICT (config_setting_id, ledger_sequence) DO UPDATE SET
 			last_modified_ledger = EXCLUDED.last_modified_ledger,
@@ -2073,7 +2182,9 @@ func (w *Writer) insertConfigSettings(ctx context.Context, tx pgx.Tx, settings [
 			tx_max_write_ledger_entries = EXCLUDED.tx_max_write_ledger_entries,
 			tx_max_write_bytes = EXCLUDED.tx_max_write_bytes,
 			contract_max_size_bytes = EXCLUDED.contract_max_size_bytes,
-			config_setting_xdr = EXCLUDED.config_setting_xdr
+			config_setting_xdr = EXCLUDED.config_setting_xdr,
+			era_id = EXCLUDED.era_id,
+			version_label = EXCLUDED.version_label
 	`
 
 	batch := &pgx.Batch{}
@@ -2101,6 +2212,8 @@ func (w *Writer) insertConfigSettings(ctx context.Context, tx pgx.Tx, settings [
 			setting.ConfigSettingXDR,
 			setting.CreatedAt,
 			setting.LedgerRange,
+			setting.EraID,
+			setting.VersionLabel,
 		)
 	}
 
@@ -2124,16 +2237,18 @@ func (w *Writer) insertTTL(ctx context.Context, tx pgx.Tx, ttls []TTLData) error
 	query := `
 		INSERT INTO ttl_snapshot_v1 (
 			key_hash, ledger_sequence, live_until_ledger_seq, ttl_remaining, expired,
-			last_modified_ledger, deleted, closed_at, created_at, ledger_range
+			last_modified_ledger, deleted, closed_at, created_at, ledger_range, era_id, version_label
 		) VALUES (
-			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10
+			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12
 		)
 		ON CONFLICT (key_hash, ledger_sequence) DO UPDATE SET
 			live_until_ledger_seq = EXCLUDED.live_until_ledger_seq,
 			ttl_remaining = EXCLUDED.ttl_remaining,
 			expired = EXCLUDED.expired,
 			last_modified_ledger = EXCLUDED.last_modified_ledger,
-			deleted = EXCLUDED.deleted
+			deleted = EXCLUDED.deleted,
+			era_id = EXCLUDED.era_id,
+			version_label = EXCLUDED.version_label
 	`
 
 	batch := &pgx.Batch{}
@@ -2150,6 +2265,8 @@ func (w *Writer) insertTTL(ctx context.Context, tx pgx.Tx, ttls []TTLData) error
 			ttl.ClosedAt,
 			ttl.CreatedAt,
 			ttl.LedgerRange,
+			ttl.EraID,
+			ttl.VersionLabel,
 		)
 	}
 
@@ -2173,14 +2290,16 @@ func (w *Writer) insertEvictedKeys(ctx context.Context, tx pgx.Tx, keys []Evicte
 	query := `
 		INSERT INTO evicted_keys_state_v1 (
 			key_hash, ledger_sequence, contract_id, key_type, durability,
-			closed_at, ledger_range, created_at
+			closed_at, ledger_range, created_at, era_id, version_label
 		) VALUES (
-			$1, $2, $3, $4, $5, $6, $7, $8
+			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10
 		)
 		ON CONFLICT (key_hash, ledger_sequence) DO UPDATE SET
 			contract_id = EXCLUDED.contract_id,
 			key_type = EXCLUDED.key_type,
-			durability = EXCLUDED.durability
+			durability = EXCLUDED.durability,
+			era_id = EXCLUDED.era_id,
+			version_label = EXCLUDED.version_label
 	`
 
 	batch := &pgx.Batch{}
@@ -2195,6 +2314,8 @@ func (w *Writer) insertEvictedKeys(ctx context.Context, tx pgx.Tx, keys []Evicte
 			key.ClosedAt,
 			key.LedgerRange,
 			key.CreatedAt,
+			key.EraID,
+			key.VersionLabel,
 		)
 	}
 
@@ -2235,7 +2356,7 @@ func (w *Writer) insertContractEvents(ctx context.Context, tx pgx.Tx, events []C
 		"event_type", "in_successful_contract_call", "successful", "contract_event_xdr",
 		"topics_json", "topics_decoded", "data_xdr", "data_decoded", "topic_count",
 		"topic0_decoded", "topic1_decoded", "topic2_decoded", "topic3_decoded",
-		"operation_index", "event_index", "created_at", "ledger_range",
+		"operation_index", "event_index", "created_at", "ledger_range", "era_id", "version_label",
 	}
 
 	rows := make([][]interface{}, len(events))
@@ -2263,6 +2384,8 @@ func (w *Writer) insertContractEvents(ctx context.Context, tx pgx.Tx, events []C
 			event.EventIndex,
 			event.CreatedAt,
 			event.LedgerRange,
+			event.EraID,
+			event.VersionLabel,
 		}
 	}
 
@@ -2282,14 +2405,14 @@ func (w *Writer) insertContractEvents(ctx context.Context, tx pgx.Tx, events []C
 			event_type, in_successful_contract_call, successful, contract_event_xdr,
 			topics_json, topics_decoded, data_xdr, data_decoded, topic_count,
 			topic0_decoded, topic1_decoded, topic2_decoded, topic3_decoded,
-			operation_index, event_index, created_at, ledger_range
+			operation_index, event_index, created_at, ledger_range, era_id, version_label
 		)
 		SELECT DISTINCT ON (ledger_sequence, transaction_hash, event_index)
 			event_id, contract_id, ledger_sequence, transaction_hash, closed_at,
 			event_type, in_successful_contract_call, successful, contract_event_xdr,
 			topics_json, topics_decoded, data_xdr, data_decoded, topic_count,
 			topic0_decoded, topic1_decoded, topic2_decoded, topic3_decoded,
-			operation_index, event_index, created_at, ledger_range
+			operation_index, event_index, created_at, ledger_range, era_id, version_label
 		FROM _tmp_events
 		ON CONFLICT (ledger_sequence, transaction_hash, event_index) DO UPDATE SET
 			contract_id = EXCLUDED.contract_id,
@@ -2305,7 +2428,9 @@ func (w *Writer) insertContractEvents(ctx context.Context, tx pgx.Tx, events []C
 			topic0_decoded = EXCLUDED.topic0_decoded,
 			topic1_decoded = EXCLUDED.topic1_decoded,
 			topic2_decoded = EXCLUDED.topic2_decoded,
-			topic3_decoded = EXCLUDED.topic3_decoded
+			topic3_decoded = EXCLUDED.topic3_decoded,
+			era_id = EXCLUDED.era_id,
+			version_label = EXCLUDED.version_label
 	`)
 	if err != nil {
 		return fmt.Errorf("failed to upsert contract events from temp: %w", err)
@@ -2347,7 +2472,7 @@ func (w *Writer) insertContractData(ctx context.Context, tx pgx.Tx, contractData
 		"balance_holder", "balance",
 		"last_modified_ledger", "ledger_entry_change", "deleted", "closed_at",
 		"contract_data_xdr", "created_at", "ledger_range",
-		"token_name", "token_symbol", "token_decimals",
+		"token_name", "token_symbol", "token_decimals", "era_id", "version_label",
 	}
 
 	rows := make([][]interface{}, len(contractDataList))
@@ -2373,6 +2498,8 @@ func (w *Writer) insertContractData(ctx context.Context, tx pgx.Tx, contractData
 			data.TokenName,
 			data.TokenSymbol,
 			data.TokenDecimals,
+			data.EraID,
+			data.VersionLabel,
 		}
 	}
 
@@ -2392,7 +2519,7 @@ func (w *Writer) insertContractData(ctx context.Context, tx pgx.Tx, contractData
 			balance_holder, balance,
 			last_modified_ledger, ledger_entry_change, deleted, closed_at,
 			contract_data_xdr, created_at, ledger_range,
-			token_name, token_symbol, token_decimals
+			token_name, token_symbol, token_decimals, era_id, version_label
 		)
 		SELECT DISTINCT ON (contract_id, ledger_key_hash, ledger_sequence)
 			contract_id, ledger_sequence, ledger_key_hash,
@@ -2401,7 +2528,7 @@ func (w *Writer) insertContractData(ctx context.Context, tx pgx.Tx, contractData
 			balance_holder, balance,
 			last_modified_ledger, ledger_entry_change, deleted, closed_at,
 			contract_data_xdr, created_at, ledger_range,
-			token_name, token_symbol, token_decimals
+			token_name, token_symbol, token_decimals, era_id, version_label
 		FROM _tmp_contract_data
 		ON CONFLICT (contract_id, ledger_key_hash, ledger_sequence) DO UPDATE SET
 			contract_key_type = EXCLUDED.contract_key_type,
@@ -2417,7 +2544,9 @@ func (w *Writer) insertContractData(ctx context.Context, tx pgx.Tx, contractData
 			contract_data_xdr = EXCLUDED.contract_data_xdr,
 			token_name = EXCLUDED.token_name,
 			token_symbol = EXCLUDED.token_symbol,
-			token_decimals = EXCLUDED.token_decimals
+			token_decimals = EXCLUDED.token_decimals,
+			era_id = EXCLUDED.era_id,
+			version_label = EXCLUDED.version_label
 	`)
 	if err != nil {
 		return fmt.Errorf("failed to upsert contract data from temp: %w", err)
@@ -2439,9 +2568,9 @@ func (w *Writer) insertContractCode(ctx context.Context, tx pgx.Tx, contractCode
 			ledger_sequence,
 			n_instructions, n_functions, n_globals, n_table_entries, n_types,
 			n_data_segments, n_elem_segments, n_imports, n_exports, n_data_segment_bytes,
-			created_at, ledger_range
+			created_at, ledger_range, era_id, version_label
 		) VALUES (
-			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20
+			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22
 		)
 		ON CONFLICT (contract_code_hash, ledger_sequence) DO UPDATE SET
 			ledger_key_hash = EXCLUDED.ledger_key_hash,
@@ -2458,7 +2587,9 @@ func (w *Writer) insertContractCode(ctx context.Context, tx pgx.Tx, contractCode
 			n_elem_segments = EXCLUDED.n_elem_segments,
 			n_imports = EXCLUDED.n_imports,
 			n_exports = EXCLUDED.n_exports,
-			n_data_segment_bytes = EXCLUDED.n_data_segment_bytes
+			n_data_segment_bytes = EXCLUDED.n_data_segment_bytes,
+			era_id = EXCLUDED.era_id,
+			version_label = EXCLUDED.version_label
 	`
 
 	for _, code := range contractCodeList {
@@ -2483,6 +2614,8 @@ func (w *Writer) insertContractCode(ctx context.Context, tx pgx.Tx, contractCode
 			code.NDataSegmentBytes,
 			code.CreatedAt,
 			code.LedgerRange,
+			code.EraID,
+			code.VersionLabel,
 		)
 		if err != nil {
 			return fmt.Errorf("failed to insert contract code %s: %w", code.ContractCodeHash, err)
@@ -2502,9 +2635,9 @@ func (w *Writer) insertNativeBalances(ctx context.Context, tx pgx.Tx, nativeBala
 		INSERT INTO native_balances_snapshot_v1 (
 			account_id, balance, buying_liabilities, selling_liabilities,
 			num_subentries, num_sponsoring, num_sponsored, sequence_number,
-			last_modified_ledger, ledger_sequence, ledger_range
+			last_modified_ledger, ledger_sequence, ledger_range, era_id, version_label
 		) VALUES (
-			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
+			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13
 		)
 		ON CONFLICT (account_id, ledger_sequence) DO UPDATE SET
 			balance = EXCLUDED.balance,
@@ -2514,7 +2647,9 @@ func (w *Writer) insertNativeBalances(ctx context.Context, tx pgx.Tx, nativeBala
 			num_sponsoring = EXCLUDED.num_sponsoring,
 			num_sponsored = EXCLUDED.num_sponsored,
 			sequence_number = EXCLUDED.sequence_number,
-			last_modified_ledger = EXCLUDED.last_modified_ledger
+			last_modified_ledger = EXCLUDED.last_modified_ledger,
+			era_id = EXCLUDED.era_id,
+			version_label = EXCLUDED.version_label
 	`
 
 	batch := &pgx.Batch{}
@@ -2532,6 +2667,8 @@ func (w *Writer) insertNativeBalances(ctx context.Context, tx pgx.Tx, nativeBala
 			nb.LastModifiedLedger,
 			nb.LedgerSequence,
 			nb.LedgerRange,
+			nb.EraID,
+			nb.VersionLabel,
 		)
 	}
 
@@ -2556,15 +2693,17 @@ func (w *Writer) insertRestoredKeys(ctx context.Context, tx pgx.Tx, restoredKeys
 		INSERT INTO restored_keys_state_v1 (
 			key_hash, ledger_sequence,
 			contract_id, key_type, durability, restored_from_ledger,
-			closed_at, ledger_range, created_at
+			closed_at, ledger_range, created_at, era_id, version_label
 		) VALUES (
-			$1, $2, $3, $4, $5, $6, $7, $8, $9
+			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
 		)
 		ON CONFLICT (key_hash, ledger_sequence) DO UPDATE SET
 			contract_id = EXCLUDED.contract_id,
 			key_type = EXCLUDED.key_type,
 			durability = EXCLUDED.durability,
-			restored_from_ledger = EXCLUDED.restored_from_ledger
+			restored_from_ledger = EXCLUDED.restored_from_ledger,
+			era_id = EXCLUDED.era_id,
+			version_label = EXCLUDED.version_label
 	`
 
 	for _, rk := range restoredKeysList {
@@ -2578,6 +2717,8 @@ func (w *Writer) insertRestoredKeys(ctx context.Context, tx pgx.Tx, restoredKeys
 			rk.ClosedAt,
 			rk.LedgerRange,
 			rk.CreatedAt,
+			rk.EraID,
+			rk.VersionLabel,
 		)
 		if err != nil {
 			return fmt.Errorf("failed to insert restored key %s: %w", rk.KeyHash, err)
@@ -2596,8 +2737,8 @@ func (w *Writer) insertContractCreations(ctx context.Context, tx pgx.Tx, creatio
 	query := `
 		INSERT INTO contract_creations_v1 (
 			contract_id, creator_address, wasm_hash,
-			created_ledger, created_at, ledger_range
-		) VALUES ($1, $2, $3, $4, $5, $6)
+			created_ledger, created_at, ledger_range, era_id, version_label
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 		ON CONFLICT (contract_id) DO NOTHING
 	`
 
@@ -2609,6 +2750,8 @@ func (w *Writer) insertContractCreations(ctx context.Context, tx pgx.Tx, creatio
 			c.CreatedLedger,
 			c.CreatedAt,
 			c.LedgerRange,
+			c.EraID,
+			c.VersionLabel,
 		)
 		if err != nil {
 			return fmt.Errorf("failed to insert contract creation %s: %w", c.ContractID, err)
@@ -2680,7 +2823,7 @@ func (w *Writer) insertTokenTransfers(ctx context.Context, tx pgx.Tx, transfers 
 		"ledger_sequence", "transaction_hash", "transaction_id", "operation_id",
 		"operation_index", "event_type", "from", "to", "asset", "asset_type",
 		"asset_code", "asset_issuer", "amount", "amount_raw", "contract_id",
-		"closed_at", "created_at", "ledger_range",
+		"closed_at", "created_at", "ledger_range", "era_id", "version_label",
 	}
 
 	rows := make([][]interface{}, len(transfers))
@@ -2704,6 +2847,8 @@ func (w *Writer) insertTokenTransfers(ctx context.Context, tx pgx.Tx, transfers 
 			t.ClosedAt,
 			t.CreatedAt,
 			t.LedgerRange,
+			t.EraID,
+			t.VersionLabel,
 		}
 	}
 
@@ -2720,13 +2865,13 @@ func (w *Writer) insertTokenTransfers(ctx context.Context, tx pgx.Tx, transfers 
 			ledger_sequence, transaction_hash, transaction_id, operation_id,
 			operation_index, event_type, "from", "to", asset, asset_type,
 			asset_code, asset_issuer, amount, amount_raw, contract_id,
-			closed_at, created_at, ledger_range
+			closed_at, created_at, ledger_range, era_id, version_label
 		)
 		SELECT DISTINCT ON (ledger_sequence, transaction_hash, operation_index, event_type, "from", "to", amount_raw)
 			ledger_sequence, transaction_hash, transaction_id, operation_id,
 			operation_index, event_type, "from", "to", asset, asset_type,
 			asset_code, asset_issuer, amount, amount_raw, contract_id,
-			closed_at, created_at, ledger_range
+			closed_at, created_at, ledger_range, era_id, version_label
 		FROM _tmp_token_transfers
 		ON CONFLICT DO NOTHING
 	`)

--- a/obsrvr-lake/stellar-postgres-ingester/migrations/007_add_versioning_metadata.sql
+++ b/obsrvr-lake/stellar-postgres-ingester/migrations/007_add_versioning_metadata.sql
@@ -1,0 +1,65 @@
+-- Migration 007: add incremental-versioning metadata to bronze hot tables
+-- Safe to run repeatedly.
+
+ALTER TABLE ledgers_row_v2 ADD COLUMN IF NOT EXISTS era_id TEXT;
+ALTER TABLE ledgers_row_v2 ADD COLUMN IF NOT EXISTS version_label TEXT;
+
+ALTER TABLE transactions_row_v2 ADD COLUMN IF NOT EXISTS era_id TEXT;
+ALTER TABLE transactions_row_v2 ADD COLUMN IF NOT EXISTS version_label TEXT;
+
+ALTER TABLE operations_row_v2 ADD COLUMN IF NOT EXISTS era_id TEXT;
+ALTER TABLE operations_row_v2 ADD COLUMN IF NOT EXISTS version_label TEXT;
+
+ALTER TABLE effects_row_v1 ADD COLUMN IF NOT EXISTS era_id TEXT;
+ALTER TABLE effects_row_v1 ADD COLUMN IF NOT EXISTS version_label TEXT;
+
+ALTER TABLE trades_row_v1 ADD COLUMN IF NOT EXISTS era_id TEXT;
+ALTER TABLE trades_row_v1 ADD COLUMN IF NOT EXISTS version_label TEXT;
+
+ALTER TABLE accounts_snapshot_v1 ADD COLUMN IF NOT EXISTS era_id TEXT;
+ALTER TABLE accounts_snapshot_v1 ADD COLUMN IF NOT EXISTS version_label TEXT;
+
+ALTER TABLE offers_snapshot_v1 ADD COLUMN IF NOT EXISTS era_id TEXT;
+ALTER TABLE offers_snapshot_v1 ADD COLUMN IF NOT EXISTS version_label TEXT;
+
+ALTER TABLE trustlines_snapshot_v1 ADD COLUMN IF NOT EXISTS era_id TEXT;
+ALTER TABLE trustlines_snapshot_v1 ADD COLUMN IF NOT EXISTS version_label TEXT;
+
+ALTER TABLE account_signers_snapshot_v1 ADD COLUMN IF NOT EXISTS era_id TEXT;
+ALTER TABLE account_signers_snapshot_v1 ADD COLUMN IF NOT EXISTS version_label TEXT;
+
+ALTER TABLE claimable_balances_snapshot_v1 ADD COLUMN IF NOT EXISTS era_id TEXT;
+ALTER TABLE claimable_balances_snapshot_v1 ADD COLUMN IF NOT EXISTS version_label TEXT;
+
+ALTER TABLE liquidity_pools_snapshot_v1 ADD COLUMN IF NOT EXISTS era_id TEXT;
+ALTER TABLE liquidity_pools_snapshot_v1 ADD COLUMN IF NOT EXISTS version_label TEXT;
+
+ALTER TABLE config_settings_snapshot_v1 ADD COLUMN IF NOT EXISTS era_id TEXT;
+ALTER TABLE config_settings_snapshot_v1 ADD COLUMN IF NOT EXISTS version_label TEXT;
+
+ALTER TABLE ttl_snapshot_v1 ADD COLUMN IF NOT EXISTS era_id TEXT;
+ALTER TABLE ttl_snapshot_v1 ADD COLUMN IF NOT EXISTS version_label TEXT;
+
+ALTER TABLE evicted_keys_state_v1 ADD COLUMN IF NOT EXISTS era_id TEXT;
+ALTER TABLE evicted_keys_state_v1 ADD COLUMN IF NOT EXISTS version_label TEXT;
+
+ALTER TABLE contract_events_stream_v1 ADD COLUMN IF NOT EXISTS era_id TEXT;
+ALTER TABLE contract_events_stream_v1 ADD COLUMN IF NOT EXISTS version_label TEXT;
+
+ALTER TABLE contract_data_snapshot_v1 ADD COLUMN IF NOT EXISTS era_id TEXT;
+ALTER TABLE contract_data_snapshot_v1 ADD COLUMN IF NOT EXISTS version_label TEXT;
+
+ALTER TABLE contract_code_snapshot_v1 ADD COLUMN IF NOT EXISTS era_id TEXT;
+ALTER TABLE contract_code_snapshot_v1 ADD COLUMN IF NOT EXISTS version_label TEXT;
+
+ALTER TABLE native_balances_snapshot_v1 ADD COLUMN IF NOT EXISTS era_id TEXT;
+ALTER TABLE native_balances_snapshot_v1 ADD COLUMN IF NOT EXISTS version_label TEXT;
+
+ALTER TABLE restored_keys_state_v1 ADD COLUMN IF NOT EXISTS era_id TEXT;
+ALTER TABLE restored_keys_state_v1 ADD COLUMN IF NOT EXISTS version_label TEXT;
+
+ALTER TABLE contract_creations_v1 ADD COLUMN IF NOT EXISTS era_id TEXT;
+ALTER TABLE contract_creations_v1 ADD COLUMN IF NOT EXISTS version_label TEXT;
+
+ALTER TABLE token_transfers_stream_v1 ADD COLUMN IF NOT EXISTS era_id TEXT;
+ALTER TABLE token_transfers_stream_v1 ADD COLUMN IF NOT EXISTS version_label TEXT;

--- a/obsrvr-lake/stellar-query-api/go/ledger_summary.go
+++ b/obsrvr-lake/stellar-query-api/go/ledger_summary.go
@@ -1,0 +1,1203 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/stellar/go/strkey"
+)
+
+type LedgerSummaryHandler struct {
+	queryService *QueryService
+	unified      *UnifiedDuckDBReader
+	hot          *SilverHotReader
+}
+
+func NewLedgerSummaryHandler(queryService *QueryService, unified *UnifiedDuckDBReader, hot *SilverHotReader) *LedgerSummaryHandler {
+	return &LedgerSummaryHandler{
+		queryService: queryService,
+		unified:      unified,
+		hot:          hot,
+	}
+}
+
+type LedgerSummaryResponse struct {
+	Ledger                     LedgerSummaryLedger              `json:"ledger"`
+	Totals                     LedgerSummaryTotals              `json:"totals"`
+	ClassificationCounts       LedgerSummaryClassifications     `json:"classification_counts"`
+	SorobanUtilization         *LedgerSummarySorobanUtilization `json:"soroban_utilization,omitempty"`
+	Sampling                   *LedgerSummarySampling           `json:"sampling,omitempty"`
+	RepresentativeTransactions []LedgerRepresentativeTx         `json:"representative_transactions,omitempty"`
+	Composition                *LedgerSummaryComposition        `json:"composition,omitempty"`
+	Provenance                 LedgerSummaryProvenance          `json:"provenance"`
+}
+
+type LedgerSummaryLedger struct {
+	Sequence          int64   `json:"sequence"`
+	ClosedAt          string  `json:"closed_at"`
+	CloseTimeSeconds  float64 `json:"close_time_seconds,omitempty"`
+	ClosedByNodeID    string  `json:"closed_by_node_id,omitempty"`
+	ClosedByValidator string  `json:"closed_by_validator,omitempty"`
+	ProtocolVersion   int     `json:"protocol_version,omitempty"`
+	Hash              string  `json:"hash,omitempty"`
+	PreviousHash      string  `json:"previous_hash,omitempty"`
+}
+
+type LedgerSummaryTotals struct {
+	TransactionCount   int64 `json:"transaction_count"`
+	SuccessfulTxCount  int64 `json:"successful_tx_count,omitempty"`
+	FailedTxCount      int64 `json:"failed_tx_count,omitempty"`
+	OperationCount     int64 `json:"operation_count,omitempty"`
+	ContractEventCount int64 `json:"contract_event_count,omitempty"`
+	SorobanOpCount     int64 `json:"soroban_op_count,omitempty"`
+	TotalFeeCharged    int64 `json:"total_fee_charged,omitempty"`
+}
+
+type LedgerSummaryClassifications struct {
+	SwapTxCount         int64 `json:"swap_tx_count,omitempty"`
+	ContractCallTxCount int64 `json:"contract_call_tx_count,omitempty"`
+	ClassicTxCount      int64 `json:"classic_tx_count,omitempty"`
+	PaymentTxCount      int64 `json:"payment_tx_count,omitempty"`
+	WalletTxCount       int64 `json:"wallet_tx_count,omitempty"`
+	DeploymentTxCount   int64 `json:"deployment_tx_count,omitempty"`
+	SorobanTxCount      int64 `json:"soroban_tx_count,omitempty"`
+}
+
+type LedgerSummarySorobanUtilization struct {
+	InstructionsUsed    int64   `json:"instructions_used,omitempty"`
+	InstructionsLimit   int64   `json:"instructions_limit,omitempty"`
+	InstructionsPct     float64 `json:"instructions_pct,omitempty"`
+	ReadBytesUsed       int64   `json:"read_bytes_used,omitempty"`
+	WriteBytesUsed      int64   `json:"write_bytes_used,omitempty"`
+	ReadWriteBytesUsed  int64   `json:"read_write_bytes_used,omitempty"`
+	ReadWriteBytesLimit int64   `json:"read_write_bytes_limit,omitempty"`
+	ReadWritePct        float64 `json:"read_write_pct,omitempty"`
+	RentBurned          float64 `json:"rent_burned,omitempty"`
+}
+
+type LedgerSummarySampling struct {
+	Strategy                    string `json:"strategy"`
+	SampleCount                 int    `json:"sample_count"`
+	RepresentedTransactionCount int64  `json:"represented_transaction_count"`
+	TotalTransactionCount       int64  `json:"total_transaction_count"`
+}
+
+type LedgerRepresentativeTx struct {
+	TxHash         string                             `json:"tx_hash"`
+	Category       string                             `json:"category"`
+	CategoryLabel  string                             `json:"category_label,omitempty"`
+	CoverageCount  int64                              `json:"coverage_count,omitempty"`
+	Classification LedgerRepresentativeClassification `json:"classification"`
+	Summary        LedgerRepresentativeSummary        `json:"summary"`
+	Actors         *LedgerRepresentativeActors        `json:"actors,omitempty"`
+}
+
+type LedgerRepresentativeClassification struct {
+	TxType     string `json:"tx_type,omitempty"`
+	Subtype    string `json:"subtype,omitempty"`
+	Confidence string `json:"confidence,omitempty"`
+}
+
+type LedgerRepresentativeSummary struct {
+	Description        string `json:"description"`
+	FunctionName       string `json:"function_name,omitempty"`
+	ProtocolLabel      string `json:"protocol_label,omitempty"`
+	ProtocolContractID string `json:"protocol_contract_id,omitempty"`
+	SoldAmount         string `json:"sold_amount,omitempty"`
+	SoldAsset          string `json:"sold_asset,omitempty"`
+	BoughtAmount       string `json:"bought_amount,omitempty"`
+	BoughtAsset        string `json:"bought_asset,omitempty"`
+	Amount             string `json:"amount,omitempty"`
+	AmountDisplay      string `json:"amount_display,omitempty"`
+	Asset              string `json:"asset,omitempty"`
+}
+
+type LedgerRepresentativeActorRef struct {
+	ID    string `json:"id,omitempty"`
+	Label string `json:"label,omitempty"`
+	Type  string `json:"type,omitempty"`
+}
+
+type LedgerRepresentativeActors struct {
+	Primary   *LedgerRepresentativeActorRef `json:"primary,omitempty"`
+	Secondary *LedgerRepresentativeActorRef `json:"secondary,omitempty"`
+}
+
+type LedgerSummaryComposition struct {
+	DominantTxType      string  `json:"dominant_tx_type,omitempty"`
+	DominantTxTypeCount int64   `json:"dominant_tx_type_count,omitempty"`
+	SorobanSharePct     float64 `json:"soroban_share_pct,omitempty"`
+	FailedSharePct      float64 `json:"failed_share_pct,omitempty"`
+}
+
+type LedgerSummaryProvenance struct {
+	ClassificationSource string `json:"classification_source,omitempty"`
+	UtilizationSource    string `json:"utilization_source,omitempty"`
+	SamplingSource       string `json:"sampling_source,omitempty"`
+	Partial              bool   `json:"partial"`
+}
+
+type ledgerSummaryTxAgg struct {
+	TxHash              string
+	LedgerSequence      int64
+	ClosedAt            string
+	SourceAccount       string
+	FeeCharged          int64
+	OpCount             int64
+	Successful          bool
+	HasSoroban          bool
+	HasPayment          bool
+	HasClassicSwap      bool
+	HasWalletInvolved   bool
+	HasDeployment       bool
+	PrimaryContract     string
+	PrimaryContractName string
+	PrimaryContractType string
+	FunctionName        string
+	PaymentAssetCode    string
+	PaymentAmount       string
+	ActivityType        string
+	ActivityDescription string
+	DestinationAccount  string
+	PrimaryCategory     string
+}
+
+type txSummaryPreview struct {
+	TxType          string
+	Description     string
+	FunctionName    string
+	PrimaryContract string
+}
+
+type ledgerSemanticActivity struct {
+	TransactionHash    string
+	ActivityType       string
+	Description        string
+	ContractID         string
+	SourceAccount      string
+	DestinationAccount string
+	AssetCode          string
+	Amount             string
+	FunctionName       string
+}
+
+type ledgerContractLabel struct {
+	ContractID     string
+	DisplayName    string
+	Category       string
+	WalletType     string
+	DeployedLedger int64
+}
+
+// HandleLedgerSummary returns a compact ledger-level summary.
+// @Summary Get ledger summary
+// @Description Returns a structured ledger summary with totals, semantic composition, Soroban utilization, representative transactions, and provenance metadata.
+// @Tags Ledgers
+// @Accept json
+// @Produce json
+// @Param seq path int true "Ledger sequence number"
+// @Success 200 {object} LedgerSummaryResponse "Ledger summary"
+// @Failure 400 {object} map[string]interface{} "Invalid ledger sequence"
+// @Failure 404 {object} map[string]interface{} "Ledger not found"
+// @Failure 500 {object} map[string]interface{} "Internal server error"
+// @Router /api/v1/silver/ledgers/{seq}/summary [get]
+func (h *LedgerSummaryHandler) HandleLedgerSummary(w http.ResponseWriter, r *http.Request) {
+	if h == nil || h.queryService == nil {
+		respondError(w, "ledger summary handler unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	vars := mux.Vars(r)
+	seqStr := vars["seq"]
+	seq, err := strconv.ParseInt(seqStr, 10, 64)
+	if err != nil {
+		respondError(w, "invalid ledger sequence", http.StatusBadRequest)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+	defer cancel()
+
+	ledgerRow, err := h.getLedgerRow(ctx, seq)
+	if err != nil {
+		respondError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if ledgerRow == nil {
+		respondError(w, fmt.Sprintf("ledger not found: %d", seq), http.StatusNotFound)
+		return
+	}
+
+	resp := LedgerSummaryResponse{
+		Ledger: LedgerSummaryLedger{
+			Sequence: seq,
+			ClosedAt: ledgerTimeString(ledgerRow["closed_at"]),
+		},
+		Totals: LedgerSummaryTotals{
+			TransactionCount:   mapInt64(ledgerRow["transaction_count"]),
+			SuccessfulTxCount:  mapInt64(ledgerRow["successful_tx_count"]),
+			FailedTxCount:      mapInt64(ledgerRow["failed_tx_count"]),
+			OperationCount:     mapInt64(ledgerRow["operation_count"]),
+			ContractEventCount: mapInt64(ledgerRow["contract_events_count"]),
+			SorobanOpCount:     mapInt64(ledgerRow["soroban_op_count"]),
+			TotalFeeCharged:    mapInt64(ledgerRow["total_fee_charged"]),
+		},
+		Provenance: LedgerSummaryProvenance{
+			ClassificationSource: "derived_from_enriched_history_operations_v1",
+			UtilizationSource:    "transactions_row_v2_plus_config_settings_current_v1",
+			SamplingSource:       "deterministic_primary_category_ranking_v1",
+			Partial:              false,
+		},
+	}
+
+	if hash, ok := ledgerRow["ledger_hash"].(string); ok {
+		resp.Ledger.Hash = hash
+	}
+	if prev, ok := ledgerRow["previous_ledger_hash"].(string); ok {
+		resp.Ledger.PreviousHash = prev
+	}
+	resp.Ledger.ProtocolVersion = int(mapInt64(ledgerRow["protocol_version"]))
+	if closedBy, ok := ledgerRow["node_id"].(string); ok {
+		resp.Ledger.ClosedByNodeID = closedBy
+		resp.Ledger.ClosedByValidator = decodeValidatorAccountID(closedBy)
+	}
+
+	txAggs, err := h.getLedgerTxAggs(ctx, seq)
+	if err != nil {
+		resp.Provenance.Partial = true
+	} else {
+		activities, activityErr := h.getLedgerSemanticActivities(ctx, seq)
+		if activityErr != nil {
+			resp.Provenance.Partial = true
+		}
+		labels, labelErr := h.getContractLabels(ctx, contractIDsFromTxAggs(txAggs))
+		if labelErr != nil {
+			resp.Provenance.Partial = true
+		}
+		applySemanticEnhancement(txAggs, activities, labels)
+		hydratePrimaryCategories(txAggs)
+		resp.ClassificationCounts = buildClassificationCounts(txAggs)
+		resp.Composition = buildComposition(resp.Totals, txAggs)
+		resp.Sampling, resp.RepresentativeTransactions = h.buildSamplingAndSamples(ctx, txAggs)
+	}
+
+	utilization, err := h.getSorobanUtilization(ctx, seq)
+	if err != nil {
+		resp.Provenance.Partial = true
+	} else if utilization != nil {
+		resp.SorobanUtilization = utilization
+	}
+
+	respondJSON(w, resp)
+}
+
+func (h *LedgerSummaryHandler) getLedgerRow(ctx context.Context, seq int64) (map[string]interface{}, error) {
+	queryHot, queryCold, hotStart, hotEnd, coldStart, coldEnd := h.queryService.determineSource(seq, seq)
+
+	var ledger map[string]interface{}
+	if queryHot {
+		rows, err := h.queryService.hot.QueryLedgers(ctx, hotStart, hotEnd, 1, "sequence_asc")
+		if err != nil {
+			return nil, err
+		}
+		results, err := scanLedgers(rows)
+		rows.Close()
+		if err != nil {
+			return nil, err
+		}
+		if len(results) > 0 {
+			ledger = results[0]
+		}
+	}
+	if ledger == nil && queryCold {
+		rows, err := h.queryService.cold.QueryLedgers(ctx, coldStart, coldEnd, 1, "sequence_asc")
+		if err != nil {
+			return nil, err
+		}
+		results, err := scanLedgers(rows)
+		rows.Close()
+		if err != nil {
+			return nil, err
+		}
+		if len(results) > 0 {
+			ledger = results[0]
+		}
+	}
+	return ledger, nil
+}
+
+func (h *LedgerSummaryHandler) getLedgerTxAggs(ctx context.Context, seq int64) ([]ledgerSummaryTxAgg, error) {
+	if h.unified == nil {
+		return nil, fmt.Errorf("unified reader unavailable")
+	}
+
+	summaryQuery := fmt.Sprintf(`
+		SELECT transaction_hash,
+		       MIN(ledger_sequence) as ledger_seq,
+		       MIN(ledger_closed_at) as closed_at,
+		       MIN(source_account) as source_account,
+		       MIN(tx_fee_charged) as fee_charged,
+		       COUNT(*) as op_count,
+		       BOOL_AND(tx_successful) as successful,
+		       BOOL_OR(is_soroban_op) as has_soroban,
+		       MIN(contract_id) FILTER (WHERE contract_id IS NOT NULL) as primary_contract
+		FROM %s.enriched_history_operations
+		WHERE ledger_sequence = $1
+		GROUP BY transaction_hash
+		ORDER BY MIN(operation_index)
+	`, h.unified.hotSchema)
+
+	rows, err := h.unified.db.QueryContext(ctx, summaryQuery, seq)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []ledgerSummaryTxAgg
+	indexByHash := map[string]int{}
+	for rows.Next() {
+		var item ledgerSummaryTxAgg
+		var closedAt sql.NullString
+		var sourceAccount sql.NullString
+		var feeCharged sql.NullInt64
+		var hasSoroban sql.NullBool
+		var primaryContract sql.NullString
+		if err := rows.Scan(
+			&item.TxHash,
+			&item.LedgerSequence,
+			&closedAt,
+			&sourceAccount,
+			&feeCharged,
+			&item.OpCount,
+			&item.Successful,
+			&hasSoroban,
+			&primaryContract,
+		); err != nil {
+			return nil, err
+		}
+		if closedAt.Valid {
+			item.ClosedAt = closedAt.String
+		}
+		if sourceAccount.Valid {
+			item.SourceAccount = sourceAccount.String
+		}
+		if feeCharged.Valid {
+			item.FeeCharged = feeCharged.Int64
+		}
+		if hasSoroban.Valid {
+			item.HasSoroban = hasSoroban.Bool
+		}
+		if primaryContract.Valid {
+			item.PrimaryContract = primaryContract.String
+		}
+		indexByHash[item.TxHash] = len(out)
+		out = append(out, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if len(out) == 0 {
+		return h.getServingLedgerTxAggs(ctx, seq)
+	}
+
+	opRows, err := h.unified.db.QueryContext(ctx, fmt.Sprintf(`
+		SELECT transaction_hash,
+		       COALESCE(is_payment_op, false),
+		       COALESCE(type, 0),
+		       COALESCE(contract_id, ''),
+		       COALESCE(function_name, ''),
+		       COALESCE(asset_code, ''),
+		       COALESCE(CAST(amount AS VARCHAR), ''),
+		       COALESCE(destination, '')
+		FROM %s.enriched_history_operations
+		WHERE ledger_sequence = $1
+		ORDER BY transaction_hash, operation_index
+	`, h.unified.hotSchema), seq)
+	if err != nil {
+		return nil, err
+	}
+	defer opRows.Close()
+
+	for opRows.Next() {
+		var txHash, contractID, functionName, assetCode, amount, destination string
+		var isPayment bool
+		var opType int32
+		if err := opRows.Scan(&txHash, &isPayment, &opType, &contractID, &functionName, &assetCode, &amount, &destination); err != nil {
+			return nil, err
+		}
+		idx, ok := indexByHash[txHash]
+		if !ok {
+			continue
+		}
+		item := &out[idx]
+		if isPayment {
+			item.HasPayment = true
+			if item.PaymentAssetCode == "" {
+				item.PaymentAssetCode = assetCode
+			}
+			if item.PaymentAmount == "" {
+				item.PaymentAmount = amount
+			}
+			if item.DestinationAccount == "" {
+				item.DestinationAccount = destination
+			}
+		}
+		if opType == 2 || opType == 3 || opType == 4 || opType == 12 || opType == 13 || opType == 22 || opType == 23 {
+			item.HasClassicSwap = true
+		}
+		if item.PrimaryContract == "" && contractID != "" {
+			item.PrimaryContract = contractID
+		}
+		if item.FunctionName == "" && functionName != "" {
+			item.FunctionName = functionName
+		}
+	}
+	if err := opRows.Err(); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+func (h *LedgerSummaryHandler) getServingLedgerTxAggs(ctx context.Context, seq int64) ([]ledgerSummaryTxAgg, error) {
+	if h.hot == nil || h.hot.db == nil {
+		return nil, nil
+	}
+
+	rows, err := h.hot.db.QueryContext(ctx, `
+		SELECT tx_hash, ledger_sequence, created_at, COALESCE(source_account, ''), successful,
+		       COALESCE(fee_charged_stroops, 0), COALESCE(operation_count, 0),
+		       COALESCE(tx_type, ''), COALESCE(summary_text, ''), summary_json, COALESCE(primary_contract_id, '')
+		FROM serving.sv_transactions_recent
+		WHERE ledger_sequence = $1
+		ORDER BY created_at DESC, tx_hash DESC
+	`, seq)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []ledgerSummaryTxAgg
+	for rows.Next() {
+		var (
+			item            ledgerSummaryTxAgg
+			createdAt       time.Time
+			txType          string
+			summaryText     string
+			summaryJSON     sql.NullString
+			primaryContract string
+		)
+		if err := rows.Scan(&item.TxHash, &item.LedgerSequence, &createdAt, &item.SourceAccount, &item.Successful, &item.FeeCharged, &item.OpCount, &txType, &summaryText, &summaryJSON, &primaryContract); err != nil {
+			return nil, err
+		}
+		item.ClosedAt = createdAt.UTC().Format(time.RFC3339)
+		item.PrimaryContract = primaryContract
+		applyServingSummary(&item, txType, summaryText, summaryJSON)
+		out = append(out, item)
+	}
+	return out, rows.Err()
+}
+
+func applyServingSummary(item *ledgerSummaryTxAgg, txType, summaryText string, summaryJSON sql.NullString) {
+	if item == nil {
+		return
+	}
+	item.ActivityType = txType
+	item.ActivityDescription = summaryText
+
+	var summary TxSummary
+	if summaryJSON.Valid && summaryJSON.String != "" {
+		_ = json.Unmarshal([]byte(summaryJSON.String), &summary)
+	}
+	if summary.Description != "" {
+		item.ActivityDescription = summary.Description
+	}
+	if summary.Type != "" {
+		item.ActivityType = summary.Type
+	}
+	if summary.Transfer != nil {
+		item.HasPayment = true
+		item.PaymentAssetCode = summary.Transfer.Asset
+		item.PaymentAmount = summary.Transfer.Amount
+		item.DestinationAccount = summary.Transfer.To
+	}
+	if summary.Swap != nil {
+		item.HasClassicSwap = true
+		item.PaymentAssetCode = summary.Swap.SoldAsset
+		item.PaymentAmount = summary.Swap.SoldAmount
+	}
+	if len(summary.InvolvedContracts) > 0 && item.PrimaryContract == "" {
+		item.PrimaryContract = summary.InvolvedContracts[0]
+	}
+	if txType == "contract_call" || txType == "swap" || txType == "multi_op" || txType == "invoke_host_function" {
+		item.HasSoroban = txType == "contract_call" || txType == "invoke_host_function"
+	}
+	if txType == "payment" || txType == "path_payment" {
+		item.HasPayment = true
+	}
+}
+
+func (h *LedgerSummaryHandler) getLedgerSemanticActivities(ctx context.Context, seq int64) (map[string][]ledgerSemanticActivity, error) {
+	if h.unified == nil {
+		return nil, fmt.Errorf("unified reader unavailable")
+	}
+
+	query := fmt.Sprintf(`
+		SELECT transaction_hash,
+		       COALESCE(activity_type, ''),
+		       COALESCE(description, ''),
+		       COALESCE(contract_id, ''),
+		       COALESCE(source_account, ''),
+		       COALESCE(destination_account, ''),
+		       COALESCE(asset_code, ''),
+		       COALESCE(CAST(amount AS VARCHAR), ''),
+		       COALESCE(soroban_function_name, '')
+		FROM %s.semantic_activities
+		WHERE ledger_sequence = $1
+	`, h.unified.hotSchema)
+
+	rows, err := h.unified.db.QueryContext(ctx, query, seq)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := map[string][]ledgerSemanticActivity{}
+	for rows.Next() {
+		var item ledgerSemanticActivity
+		if err := rows.Scan(
+			&item.TransactionHash,
+			&item.ActivityType,
+			&item.Description,
+			&item.ContractID,
+			&item.SourceAccount,
+			&item.DestinationAccount,
+			&item.AssetCode,
+			&item.Amount,
+			&item.FunctionName,
+		); err != nil {
+			return nil, err
+		}
+		out[item.TransactionHash] = append(out[item.TransactionHash], item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (h *LedgerSummaryHandler) getContractLabels(ctx context.Context, contractIDs []string) (map[string]ledgerContractLabel, error) {
+	if h.unified == nil || len(contractIDs) == 0 {
+		return map[string]ledgerContractLabel{}, nil
+	}
+	placeholders := make([]string, len(contractIDs))
+	args := make([]interface{}, len(contractIDs))
+	for i, id := range contractIDs {
+		placeholders[i] = fmt.Sprintf("$%d", i+1)
+		args[i] = id
+	}
+
+	query := fmt.Sprintf(`
+		SELECT sec.contract_id,
+		       COALESCE(cr.display_name, sec.token_name, sec.token_symbol, sec.contract_id) AS display_name,
+		       COALESCE(cr.category, sec.contract_type, ''),
+		       COALESCE(sec.wallet_type, ''),
+		       COALESCE(sec.deployed_ledger, 0)
+		FROM %s.semantic_entities_contracts sec
+		LEFT JOIN %s.contract_registry cr ON cr.contract_id = sec.contract_id
+		WHERE sec.contract_id IN (%s)
+	`, h.unified.hotSchema, h.unified.hotSchema, strings.Join(placeholders, ", "))
+
+	rows, err := h.unified.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := map[string]ledgerContractLabel{}
+	for rows.Next() {
+		var item ledgerContractLabel
+		if err := rows.Scan(&item.ContractID, &item.DisplayName, &item.Category, &item.WalletType, &item.DeployedLedger); err != nil {
+			return nil, err
+		}
+		out[item.ContractID] = item
+	}
+	return out, rows.Err()
+}
+
+func applySemanticEnhancement(items []ledgerSummaryTxAgg, activities map[string][]ledgerSemanticActivity, labels map[string]ledgerContractLabel) {
+	for i := range items {
+		if label, ok := labels[items[i].PrimaryContract]; ok {
+			items[i].PrimaryContractName = label.DisplayName
+			items[i].PrimaryContractType = label.Category
+			items[i].HasWalletInvolved = label.WalletType != ""
+			items[i].HasDeployment = label.DeployedLedger > 0 && label.DeployedLedger == items[i].LedgerSequence
+		}
+		for _, act := range activities[items[i].TxHash] {
+			if items[i].ActivityType == "" {
+				items[i].ActivityType = act.ActivityType
+			}
+			if items[i].ActivityDescription == "" && act.Description != "" {
+				items[i].ActivityDescription = act.Description
+			}
+			if items[i].FunctionName == "" && act.FunctionName != "" {
+				items[i].FunctionName = act.FunctionName
+			}
+			if items[i].PrimaryContract == "" && act.ContractID != "" {
+				items[i].PrimaryContract = act.ContractID
+				if label, ok := labels[act.ContractID]; ok {
+					items[i].PrimaryContractName = label.DisplayName
+					items[i].PrimaryContractType = label.Category
+					items[i].HasWalletInvolved = label.WalletType != ""
+					items[i].HasDeployment = label.DeployedLedger > 0 && label.DeployedLedger == items[i].LedgerSequence
+				}
+			}
+			if items[i].PaymentAssetCode == "" && act.AssetCode != "" {
+				items[i].PaymentAssetCode = act.AssetCode
+			}
+			if items[i].PaymentAmount == "" && act.Amount != "" {
+				items[i].PaymentAmount = act.Amount
+			}
+			if items[i].DestinationAccount == "" && act.DestinationAccount != "" {
+				items[i].DestinationAccount = act.DestinationAccount
+			}
+			if act.ActivityType == "payment" || act.ActivityType == "path_payment" {
+				items[i].HasPayment = true
+			}
+			if act.ActivityType == "contract_call" || act.ActivityType == "invoke_host_function" {
+				items[i].HasSoroban = true
+			}
+		}
+	}
+}
+
+func contractIDsFromTxAggs(items []ledgerSummaryTxAgg) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		if item.PrimaryContract == "" {
+			continue
+		}
+		if _, ok := seen[item.PrimaryContract]; ok {
+			continue
+		}
+		seen[item.PrimaryContract] = struct{}{}
+		out = append(out, item.PrimaryContract)
+	}
+	return out
+}
+
+func (h *LedgerSummaryHandler) getSorobanUtilization(ctx context.Context, seq int64) (*LedgerSummarySorobanUtilization, error) {
+	if h.unified == nil || !h.unified.hasBronze() {
+		return nil, fmt.Errorf("bronze/unified reader unavailable")
+	}
+
+	usageQuery := fmt.Sprintf(`
+		WITH txs AS (
+			SELECT DISTINCT * FROM (
+				%s
+			) bronze_txs
+		)
+		SELECT
+			COALESCE(SUM(soroban_resources_instructions), 0) AS instructions_used,
+			COALESCE(SUM(soroban_resources_read_bytes), 0) AS read_bytes_used,
+			COALESCE(SUM(soroban_resources_write_bytes), 0) AS write_bytes_used,
+			COALESCE(SUM(rent_fee_charged), 0) AS rent_burned
+		FROM txs
+	`, h.unified.bronzeUnionQuery(
+		"transaction_hash, soroban_resources_instructions, soroban_resources_read_bytes, soroban_resources_write_bytes, rent_fee_charged",
+		"transactions_row_v2",
+		"WHERE ledger_sequence = $1",
+	))
+
+	var instructionsUsed, readBytesUsed, writeBytesUsed, rentBurned sql.NullInt64
+	if err := h.unified.db.QueryRowContext(ctx, usageQuery, seq).Scan(&instructionsUsed, &readBytesUsed, &writeBytesUsed, &rentBurned); err != nil {
+		return nil, err
+	}
+
+	cfg, err := h.unified.GetSorobanConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if cfg == nil && h.hot != nil {
+		cfg, err = h.hot.GetSorobanConfig(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	resp := &LedgerSummarySorobanUtilization{
+		InstructionsUsed:   instructionsUsed.Int64,
+		ReadBytesUsed:      readBytesUsed.Int64,
+		WriteBytesUsed:     writeBytesUsed.Int64,
+		ReadWriteBytesUsed: readBytesUsed.Int64 + writeBytesUsed.Int64,
+		RentBurned:         float64(rentBurned.Int64),
+	}
+
+	if cfg != nil {
+		resp.InstructionsLimit = cfg.Instructions.LedgerMax
+		resp.ReadWriteBytesLimit = cfg.LedgerLimits.MaxReadBytes + cfg.LedgerLimits.MaxWriteBytes
+		resp.InstructionsPct = pct(resp.InstructionsUsed, resp.InstructionsLimit)
+		resp.ReadWritePct = pct(resp.ReadWriteBytesUsed, resp.ReadWriteBytesLimit)
+	}
+
+	if resp.InstructionsUsed == 0 && resp.ReadWriteBytesUsed == 0 && resp.RentBurned == 0 {
+		return nil, nil
+	}
+	return resp, nil
+}
+
+func hydratePrimaryCategories(items []ledgerSummaryTxAgg) {
+	for i := range items {
+		switch {
+		case items[i].HasDeployment:
+			items[i].PrimaryCategory = "deployment"
+		case items[i].HasClassicSwap || strings.Contains(strings.ToLower(items[i].ActivityDescription), "swapped"):
+			items[i].PrimaryCategory = "swap"
+		case items[i].HasSoroban:
+			items[i].PrimaryCategory = "contract_call"
+		case items[i].HasPayment:
+			items[i].PrimaryCategory = "classic_payment"
+		default:
+			items[i].PrimaryCategory = "classic"
+		}
+	}
+}
+
+func buildClassificationCounts(items []ledgerSummaryTxAgg) LedgerSummaryClassifications {
+	var counts LedgerSummaryClassifications
+	for _, item := range items {
+		if item.HasClassicSwap || strings.Contains(strings.ToLower(item.ActivityDescription), "swapped") {
+			counts.SwapTxCount++
+		}
+		if item.HasSoroban {
+			counts.ContractCallTxCount++
+			counts.SorobanTxCount++
+		}
+		if !item.HasSoroban {
+			counts.ClassicTxCount++
+		}
+		if item.HasPayment {
+			counts.PaymentTxCount++
+		}
+		if item.HasWalletInvolved {
+			counts.WalletTxCount++
+		}
+		if item.HasDeployment {
+			counts.DeploymentTxCount++
+		}
+	}
+	return counts
+}
+
+func buildComposition(totals LedgerSummaryTotals, items []ledgerSummaryTxAgg) *LedgerSummaryComposition {
+	if totals.TransactionCount == 0 {
+		return nil
+	}
+	primaryCounts := map[string]int64{}
+	for _, item := range items {
+		primaryCounts[item.PrimaryCategory]++
+	}
+
+	var dominantType string
+	var dominantCount int64
+	order := []string{"contract_call", "swap", "deployment", "classic_payment", "classic"}
+	for _, key := range order {
+		if primaryCounts[key] > dominantCount {
+			dominantType = key
+			dominantCount = primaryCounts[key]
+		}
+	}
+
+	sorobanCount := int64(0)
+	for _, item := range items {
+		if item.HasSoroban {
+			sorobanCount++
+		}
+	}
+
+	return &LedgerSummaryComposition{
+		DominantTxType:      dominantType,
+		DominantTxTypeCount: dominantCount,
+		SorobanSharePct:     pct(sorobanCount, totals.TransactionCount),
+		FailedSharePct:      pct(totals.FailedTxCount, totals.TransactionCount),
+	}
+}
+
+func (h *LedgerSummaryHandler) buildSamplingAndSamples(ctx context.Context, items []ledgerSummaryTxAgg) (*LedgerSummarySampling, []LedgerRepresentativeTx) {
+	if len(items) == 0 {
+		return &LedgerSummarySampling{
+			Strategy:              "one_per_dominant_kind",
+			SampleCount:           0,
+			TotalTransactionCount: 0,
+		}, nil
+	}
+
+	counts := map[string]int64{}
+	for _, item := range items {
+		counts[item.PrimaryCategory]++
+	}
+
+	categories := make([]string, 0, len(counts))
+	for category, count := range counts {
+		if count > 0 {
+			categories = append(categories, category)
+		}
+	}
+	sort.Slice(categories, func(i, j int) bool {
+		if counts[categories[i]] == counts[categories[j]] {
+			return sampleCategoryRank(categories[i]) < sampleCategoryRank(categories[j])
+		}
+		return counts[categories[i]] > counts[categories[j]]
+	})
+	if len(categories) > 3 {
+		categories = categories[:3]
+	}
+
+	previews := h.fetchSamplePreviews(ctx, selectedHashesForCategories(items, categories))
+	represented := int64(0)
+	samples := make([]LedgerRepresentativeTx, 0, len(categories))
+	for _, category := range categories {
+		best, ok := chooseBestSample(items, category)
+		if !ok {
+			continue
+		}
+		represented += counts[category]
+		samples = append(samples, buildRepresentativeTx(best, counts[category], previews[best.TxHash]))
+	}
+
+	return &LedgerSummarySampling{
+		Strategy:                    "one_per_dominant_kind",
+		SampleCount:                 len(samples),
+		RepresentedTransactionCount: represented,
+		TotalTransactionCount:       int64(len(items)),
+	}, samples
+}
+
+func selectedHashesForCategories(items []ledgerSummaryTxAgg, categories []string) []string {
+	hashes := make([]string, 0, len(categories))
+	for _, category := range categories {
+		if best, ok := chooseBestSample(items, category); ok {
+			hashes = append(hashes, best.TxHash)
+		}
+	}
+	return hashes
+}
+
+func chooseBestSample(items []ledgerSummaryTxAgg, category string) (ledgerSummaryTxAgg, bool) {
+	var chosen ledgerSummaryTxAgg
+	found := false
+	for _, item := range items {
+		if item.PrimaryCategory != category {
+			continue
+		}
+		if !found || betterSample(item, chosen) {
+			chosen = item
+			found = true
+		}
+	}
+	return chosen, found
+}
+
+func betterSample(a, b ledgerSummaryTxAgg) bool {
+	if a.Successful != b.Successful {
+		return a.Successful
+	}
+	if a.OpCount != b.OpCount {
+		return a.OpCount > b.OpCount
+	}
+	if a.FunctionName != b.FunctionName {
+		return a.FunctionName < b.FunctionName
+	}
+	return a.TxHash < b.TxHash
+}
+
+func buildRepresentativeTx(item ledgerSummaryTxAgg, coverage int64, preview txSummaryPreview) LedgerRepresentativeTx {
+	classification := LedgerRepresentativeClassification{
+		TxType:     classificationTxType(item.PrimaryCategory),
+		Confidence: "medium",
+	}
+	if item.FunctionName != "" && (item.PrimaryCategory == "contract_call" || item.PrimaryCategory == "deployment") {
+		classification.Subtype = item.FunctionName
+	}
+
+	summary := LedgerRepresentativeSummary{
+		Description: normalizeSingleLine(representativeDescription(item, preview)),
+	}
+	if item.FunctionName != "" && (item.PrimaryCategory == "contract_call" || item.PrimaryCategory == "deployment") {
+		summary.FunctionName = item.FunctionName
+	}
+	if item.PaymentAmount != "" {
+		summary.Amount = item.PaymentAmount
+		summary.AmountDisplay = item.PaymentAmount
+	}
+	if item.PaymentAssetCode != "" {
+		summary.Asset = item.PaymentAssetCode
+	}
+	if item.PrimaryContractName != "" {
+		summary.ProtocolLabel = item.PrimaryContractName
+	} else if item.PrimaryContract != "" {
+		summary.ProtocolLabel = abbreviateAddr(item.PrimaryContract)
+	} else if preview.PrimaryContract != "" {
+		summary.ProtocolLabel = abbreviateAddr(preview.PrimaryContract)
+	}
+	if item.PrimaryContract != "" {
+		summary.ProtocolContractID = item.PrimaryContract
+	} else if preview.PrimaryContract != "" {
+		summary.ProtocolContractID = preview.PrimaryContract
+	}
+
+	return LedgerRepresentativeTx{
+		TxHash:         item.TxHash,
+		Category:       item.PrimaryCategory,
+		CategoryLabel:  categoryLabel(item.PrimaryCategory),
+		CoverageCount:  coverage,
+		Classification: classification,
+		Summary:        summary,
+		Actors:         representativeActors(item),
+	}
+}
+
+func representativeDescription(item ledgerSummaryTxAgg, preview txSummaryPreview) string {
+	if item.ActivityDescription != "" {
+		return normalizeSingleLine(item.ActivityDescription)
+	}
+	if preview.Description != "" {
+		return normalizeSingleLine(preview.Description)
+	}
+	switch item.PrimaryCategory {
+	case "swap":
+		return "Representative swap transaction"
+	case "deployment":
+		if item.PrimaryContractName != "" {
+			return fmt.Sprintf("Deployed or initialized %s", item.PrimaryContractName)
+		}
+		return "Representative deployment transaction"
+	case "contract_call":
+		if item.FunctionName != "" && item.PrimaryContractName != "" {
+			return fmt.Sprintf("Called %s on %s", item.FunctionName, item.PrimaryContractName)
+		}
+		if item.FunctionName != "" {
+			return fmt.Sprintf("Called %s on a Soroban contract", item.FunctionName)
+		}
+		return "Representative Soroban contract call"
+	case "classic_payment":
+		if item.PaymentAmount != "" && item.PaymentAssetCode != "" {
+			return fmt.Sprintf("Sent %s %s", item.PaymentAmount, item.PaymentAssetCode)
+		}
+		return "Representative classic payment"
+	default:
+		return "Representative classic transaction"
+	}
+}
+
+func (h *LedgerSummaryHandler) fetchSamplePreviews(ctx context.Context, txHashes []string) map[string]txSummaryPreview {
+	if h.hot == nil || h.hot.db == nil || len(txHashes) == 0 {
+		return map[string]txSummaryPreview{}
+	}
+	placeholders := make([]string, len(txHashes))
+	args := make([]interface{}, len(txHashes))
+	for i, hash := range txHashes {
+		placeholders[i] = fmt.Sprintf("$%d", i+1)
+		args[i] = hash
+	}
+
+	query := fmt.Sprintf(`
+		SELECT tx_hash, COALESCE(tx_type, ''), COALESCE(summary_text, ''), summary_json, COALESCE(primary_contract_id, '')
+		FROM serving.sv_transactions_recent
+		WHERE tx_hash IN (%s)
+	`, strings.Join(placeholders, ", "))
+
+	rows, err := h.hot.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return map[string]txSummaryPreview{}
+	}
+	defer rows.Close()
+
+	out := map[string]txSummaryPreview{}
+	for rows.Next() {
+		var hash, txType, summaryText, primaryContract string
+		var summaryJSON sql.NullString
+		if err := rows.Scan(&hash, &txType, &summaryText, &summaryJSON, &primaryContract); err != nil {
+			continue
+		}
+		preview := txSummaryPreview{TxType: txType, Description: summaryText, PrimaryContract: primaryContract}
+		if summaryJSON.Valid && summaryJSON.String != "" {
+			var summary TxSummary
+			if err := json.Unmarshal([]byte(summaryJSON.String), &summary); err == nil {
+				if summary.Description != "" {
+					preview.Description = summary.Description
+				}
+				if summary.Type != "" {
+					preview.TxType = summary.Type
+				}
+			}
+		}
+		out[hash] = preview
+	}
+	return out
+}
+
+func pct(used, limit int64) float64 {
+	if limit <= 0 {
+		return 0
+	}
+	value := (float64(used) / float64(limit)) * 100
+	return math.Round(value*100) / 100
+}
+
+func classificationTxType(category string) string {
+	switch category {
+	case "contract_call":
+		return "contract_call"
+	case "classic_payment":
+		return "simple_payment"
+	case "deployment":
+		return "deployment"
+	case "swap":
+		return "swap"
+	case "classic":
+		return "classic"
+	default:
+		return category
+	}
+}
+
+func normalizeSingleLine(s string) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\r", " ")
+	return strings.Join(strings.Fields(s), " ")
+}
+
+func decodeValidatorAccountID(nodeID string) string {
+	if strings.TrimSpace(nodeID) == "" {
+		return ""
+	}
+	raw, err := base64.StdEncoding.DecodeString(nodeID)
+	if err != nil || len(raw) != 32 {
+		return ""
+	}
+	accountID, err := strkey.Encode(strkey.VersionByteAccountID, raw)
+	if err != nil {
+		return ""
+	}
+	return accountID
+}
+
+func representativeActors(item ledgerSummaryTxAgg) *LedgerRepresentativeActors {
+	actors := &LedgerRepresentativeActors{}
+	switch item.PrimaryCategory {
+	case "contract_call", "deployment":
+		if item.PrimaryContract != "" || item.PrimaryContractName != "" {
+			actors.Primary = &LedgerRepresentativeActorRef{
+				ID:    item.PrimaryContract,
+				Label: nonEmpty(item.PrimaryContractName, abbreviateAddr(item.PrimaryContract)),
+				Type:  nonEmpty(item.PrimaryContractType, "contract"),
+			}
+		}
+		if item.SourceAccount != "" {
+			actors.Secondary = &LedgerRepresentativeActorRef{
+				ID:    item.SourceAccount,
+				Label: abbreviateAddr(item.SourceAccount),
+				Type:  "classic_account",
+			}
+		}
+	case "classic_payment", "swap":
+		if item.SourceAccount != "" {
+			actors.Primary = &LedgerRepresentativeActorRef{
+				ID:    item.SourceAccount,
+				Label: abbreviateAddr(item.SourceAccount),
+				Type:  "classic_account",
+			}
+		}
+		if item.DestinationAccount != "" {
+			actors.Secondary = &LedgerRepresentativeActorRef{
+				ID:    item.DestinationAccount,
+				Label: abbreviateAddr(item.DestinationAccount),
+				Type:  "classic_account",
+			}
+		}
+	default:
+		if item.SourceAccount != "" {
+			actors.Primary = &LedgerRepresentativeActorRef{
+				ID:    item.SourceAccount,
+				Label: abbreviateAddr(item.SourceAccount),
+				Type:  "account",
+			}
+		}
+	}
+	if actors.Primary == nil {
+		return nil
+	}
+	return actors
+}
+
+func categoryLabel(category string) string {
+	switch category {
+	case "contract_call":
+		return "Contract Call"
+	case "classic_payment":
+		return "Classic Payment"
+	case "deployment":
+		return "Deployment"
+	case "swap":
+		return "Swap"
+	case "classic":
+		return "Classic"
+	default:
+		return strings.Title(strings.ReplaceAll(category, "_", " "))
+	}
+}
+
+func sampleCategoryRank(category string) int {
+	switch category {
+	case "contract_call":
+		return 0
+	case "swap":
+		return 1
+	case "deployment":
+		return 2
+	case "classic_payment":
+		return 3
+	case "classic":
+		return 4
+	default:
+		return 100
+	}
+}
+
+func mapInt64(v interface{}) int64 {
+	switch n := v.(type) {
+	case int64:
+		return n
+	case int:
+		return int64(n)
+	case int32:
+		return int64(n)
+	case float64:
+		return int64(n)
+	default:
+		return 0
+	}
+}
+
+func ledgerTimeString(v interface{}) string {
+	switch t := v.(type) {
+	case time.Time:
+		return t.UTC().Format(time.RFC3339)
+	case string:
+		return t
+	default:
+		return ""
+	}
+}

--- a/obsrvr-lake/stellar-query-api/go/ledger_summary.go
+++ b/obsrvr-lake/stellar-query-api/go/ledger_summary.go
@@ -288,7 +288,10 @@ func (h *LedgerSummaryHandler) HandleLedgerSummary(w http.ResponseWriter, r *htt
 		hydratePrimaryCategories(txAggs)
 		resp.ClassificationCounts = buildClassificationCounts(txAggs)
 		resp.Composition = buildComposition(resp.Totals, txAggs)
-		resp.Sampling, resp.RepresentativeTransactions = h.buildSamplingAndSamples(ctx, txAggs)
+		resp.Sampling, resp.RepresentativeTransactions, err = h.buildSamplingAndSamples(ctx, txAggs)
+		if err != nil {
+			resp.Provenance.Partial = true
+		}
 	}
 
 	utilization, err := h.getSorobanUtilization(ctx, seq)
@@ -342,6 +345,9 @@ func (h *LedgerSummaryHandler) getLedgerTxAggs(ctx context.Context, seq int64) (
 	}
 
 	summaryQuery := fmt.Sprintf(`
+		WITH dedup_ops AS (
+			%s
+		)
 		SELECT transaction_hash,
 		       MIN(ledger_sequence) as ledger_seq,
 		       MIN(ledger_closed_at) as closed_at,
@@ -350,12 +356,24 @@ func (h *LedgerSummaryHandler) getLedgerTxAggs(ctx context.Context, seq int64) (
 		       COUNT(*) as op_count,
 		       BOOL_AND(tx_successful) as successful,
 		       BOOL_OR(is_soroban_op) as has_soroban,
-		       MIN(contract_id) FILTER (WHERE contract_id IS NOT NULL) as primary_contract
-		FROM %s.enriched_history_operations
-		WHERE ledger_sequence = $1
+		       MIN(contract_id) FILTER (WHERE contract_id IS NOT NULL AND contract_id <> '') as primary_contract
+		FROM dedup_ops
 		GROUP BY transaction_hash
 		ORDER BY MIN(operation_index)
-	`, h.unified.hotSchema)
+	`, h.unifiedLedgerOpsQuery(`
+		SELECT DISTINCT ON (ledger_sequence, operation_index)
+			transaction_hash,
+			ledger_sequence,
+			ledger_closed_at,
+			source_account,
+			tx_fee_charged,
+			operation_index,
+			tx_successful,
+			is_soroban_op,
+			contract_id
+		FROM combined
+		ORDER BY ledger_sequence, operation_index, source
+	`))
 
 	rows, err := h.unified.db.QueryContext(ctx, summaryQuery, seq)
 	if err != nil {
@@ -410,7 +428,10 @@ func (h *LedgerSummaryHandler) getLedgerTxAggs(ctx context.Context, seq int64) (
 		return h.getServingLedgerTxAggs(ctx, seq)
 	}
 
-	opRows, err := h.unified.db.QueryContext(ctx, fmt.Sprintf(`
+	opQuery := fmt.Sprintf(`
+		WITH dedup_ops AS (
+			%s
+		)
 		SELECT transaction_hash,
 		       COALESCE(is_payment_op, false),
 		       COALESCE(type, 0),
@@ -419,10 +440,24 @@ func (h *LedgerSummaryHandler) getLedgerTxAggs(ctx context.Context, seq int64) (
 		       COALESCE(asset_code, ''),
 		       COALESCE(CAST(amount AS VARCHAR), ''),
 		       COALESCE(destination, '')
-		FROM %s.enriched_history_operations
-		WHERE ledger_sequence = $1
+		FROM dedup_ops
 		ORDER BY transaction_hash, operation_index
-	`, h.unified.hotSchema), seq)
+	`, h.unifiedLedgerOpsQuery(`
+		SELECT DISTINCT ON (ledger_sequence, operation_index)
+			transaction_hash,
+			is_payment_op,
+			type,
+			contract_id,
+			function_name,
+			asset_code,
+			amount,
+			destination,
+			operation_index
+		FROM combined
+		ORDER BY ledger_sequence, operation_index, source
+	`))
+
+	opRows, err := h.unified.db.QueryContext(ctx, opQuery, seq)
 	if err != nil {
 		return nil, err
 	}
@@ -467,6 +502,28 @@ func (h *LedgerSummaryHandler) getLedgerTxAggs(ctx context.Context, seq int64) (
 	}
 
 	return out, nil
+}
+
+func (h *LedgerSummaryHandler) unifiedLedgerOpsQuery(selectFromCombined string) string {
+	combined := fmt.Sprintf(`
+		WITH combined AS (
+			SELECT *, 1 AS source
+			FROM %s.enriched_history_operations
+			WHERE ledger_sequence = $1
+		`, h.unified.hotSchema)
+	if h.unified.coldSchema != "" {
+		combined += fmt.Sprintf(`
+			UNION ALL
+			SELECT *, 2 AS source
+			FROM %s.enriched_history_operations
+			WHERE ledger_sequence = $1
+		`, h.unified.coldSchema)
+	}
+	combined += fmt.Sprintf(`
+		)
+		%s
+	`, selectFromCombined)
+	return combined
 }
 
 func (h *LedgerSummaryHandler) getServingLedgerTxAggs(ctx context.Context, seq int64) ([]ledgerSummaryTxAgg, error) {
@@ -834,13 +891,13 @@ func buildComposition(totals LedgerSummaryTotals, items []ledgerSummaryTxAgg) *L
 	}
 }
 
-func (h *LedgerSummaryHandler) buildSamplingAndSamples(ctx context.Context, items []ledgerSummaryTxAgg) (*LedgerSummarySampling, []LedgerRepresentativeTx) {
+func (h *LedgerSummaryHandler) buildSamplingAndSamples(ctx context.Context, items []ledgerSummaryTxAgg) (*LedgerSummarySampling, []LedgerRepresentativeTx, error) {
 	if len(items) == 0 {
 		return &LedgerSummarySampling{
 			Strategy:              "one_per_dominant_kind",
 			SampleCount:           0,
 			TotalTransactionCount: 0,
-		}, nil
+		}, nil, nil
 	}
 
 	counts := map[string]int64{}
@@ -864,7 +921,10 @@ func (h *LedgerSummaryHandler) buildSamplingAndSamples(ctx context.Context, item
 		categories = categories[:3]
 	}
 
-	previews := h.fetchSamplePreviews(ctx, selectedHashesForCategories(items, categories))
+	previews, err := h.fetchSamplePreviews(ctx, selectedHashesForCategories(items, categories))
+	if err != nil {
+		return nil, nil, err
+	}
 	represented := int64(0)
 	samples := make([]LedgerRepresentativeTx, 0, len(categories))
 	for _, category := range categories {
@@ -881,7 +941,7 @@ func (h *LedgerSummaryHandler) buildSamplingAndSamples(ctx context.Context, item
 		SampleCount:                 len(samples),
 		RepresentedTransactionCount: represented,
 		TotalTransactionCount:       int64(len(items)),
-	}, samples
+	}, samples, nil
 }
 
 func selectedHashesForCategories(items []ledgerSummaryTxAgg, categories []string) []string {
@@ -1001,9 +1061,9 @@ func representativeDescription(item ledgerSummaryTxAgg, preview txSummaryPreview
 	}
 }
 
-func (h *LedgerSummaryHandler) fetchSamplePreviews(ctx context.Context, txHashes []string) map[string]txSummaryPreview {
+func (h *LedgerSummaryHandler) fetchSamplePreviews(ctx context.Context, txHashes []string) (map[string]txSummaryPreview, error) {
 	if h.hot == nil || h.hot.db == nil || len(txHashes) == 0 {
-		return map[string]txSummaryPreview{}
+		return map[string]txSummaryPreview{}, nil
 	}
 	placeholders := make([]string, len(txHashes))
 	args := make([]interface{}, len(txHashes))
@@ -1020,7 +1080,7 @@ func (h *LedgerSummaryHandler) fetchSamplePreviews(ctx context.Context, txHashes
 
 	rows, err := h.hot.db.QueryContext(ctx, query, args...)
 	if err != nil {
-		return map[string]txSummaryPreview{}
+		return nil, err
 	}
 	defer rows.Close()
 
@@ -1045,7 +1105,10 @@ func (h *LedgerSummaryHandler) fetchSamplePreviews(ctx context.Context, txHashes
 		}
 		out[hash] = preview
 	}
-	return out
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func pct(used, limit int64) float64 {
@@ -1155,8 +1218,20 @@ func categoryLabel(category string) string {
 	case "classic":
 		return "Classic"
 	default:
-		return strings.Title(strings.ReplaceAll(category, "_", " "))
+		return titleSnakeCase(category)
 	}
+}
+
+func titleSnakeCase(s string) string {
+	parts := strings.Split(strings.ReplaceAll(s, "-", "_"), "_")
+	for i, part := range parts {
+		part = strings.TrimSpace(strings.ToLower(part))
+		if part == "" {
+			continue
+		}
+		parts[i] = strings.ToUpper(part[:1]) + part[1:]
+	}
+	return strings.Join(parts, " ")
 }
 
 func sampleCategoryRank(category string) int {

--- a/obsrvr-lake/stellar-query-api/go/routes_silver.go
+++ b/obsrvr-lake/stellar-query-api/go/routes_silver.go
@@ -80,6 +80,11 @@ func (app *application) registerSilverRoutes(router *mux.Router) {
 
 	router.HandleFunc("/api/v1/silver/ledgers/{seq:[0-9]+}", queryService.HandleLedgerBySequence).Methods("GET")
 	router.HandleFunc("/api/v1/silver/ledger/{seq:[0-9]+}", queryService.HandleLedgerBySequence).Methods("GET")
+	if unifiedDuckDBReader != nil {
+		ledgerSummaryHandler := NewLedgerSummaryHandler(queryService, unifiedDuckDBReader, silverHotReader)
+		router.HandleFunc("/api/v1/silver/ledgers/{seq:[0-9]+}/summary", ledgerSummaryHandler.HandleLedgerSummary).Methods("GET")
+		router.HandleFunc("/api/v1/silver/ledger/{seq:[0-9]+}/summary", ledgerSummaryHandler.HandleLedgerSummary).Methods("GET")
+	}
 
 	ledgerFullHandler := NewLedgerFullHandler(queryService, silverHotReader, unifiedSilverReader)
 	router.HandleFunc("/api/v1/silver/ledger/{seq:[0-9]+}/full", ledgerFullHandler.HandleLedgerFull).Methods("GET")


### PR DESCRIPTION
This pull request introduces comprehensive documentation and code changes to improve and audit incremental versioning support throughout the `obsrvr-lake` data pipeline. The updates focus on ensuring that version metadata (`era_id`, `version_label`) is consistently preserved across hot and cold storage, and provide detailed gap analysis and next steps for achieving reconciliation-safe versioning. Additionally, schema and migration logic is updated to enforce the presence of version metadata in all relevant bronze tables.

**Key changes:**

**Documentation: Versioning Audit and Gap Analysis**
- Added `TIER1_VERSIONING_COMPATIBILITY_MATRIX.md`, providing an audit matrix and detailed notes on current Tier 1 versioning support across all major datasets and pipeline stages. This includes evidence, remaining gaps, and recommended next steps for full compliance.
- Added `VERSIONING_GAP_CHECKLIST.md`, capturing the current gaps between the desired and actual state of versioning, with per-component findings, risks, and a prioritized action plan for closing those gaps.

**Schema and Migration Improvements**
- Updated `v3_bronze_schema.sql` to add `era_id` and `version_label` columns to the `bronze.token_transfers_stream_v1` table, ensuring version metadata is present in the schema.
- Modified `applyBronzeMigrations` in `bronze_schema.go` to programmatically add `era_id` and `version_label` columns to all key versioned bronze tables if they do not already exist, enforcing schema consistency for versioning.

**Data Flushing Logic**
- Updated the explicit column list for `token_transfers_stream_v1` in `duckdb.go` to include `era_id` and `version_label`, ensuring these fields are correctly flushed to DuckDB and not lost in the migration process.

These changes collectively move the system closer to end-to-end, reconciliation-safe versioning and provide a clear roadmap for remaining work.